### PR TITLE
TravisCI: rebuild vcpkg on source change

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,8 +14,9 @@ skip_branch_with_pr: true
 skip_commits:
   files:
   - .git*
-  - .travis.yml
   - .codecov.yml
+  - .travis.yml
+  - .yamllint
   - docs/
   - LICENSE
   - '**/.clang-*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,6 @@ jobs:
         - ubuntu-toolchain-r-test
         packages:
         - clang-8
-        - g++-7
         - libc++-8-dev
         - libc++abi-8-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -344,7 +344,7 @@ before_install:
   # Install/Update vcpkg
   ( set -euxo pipefail
     if [[ ! -x "$(command -v vcpkg)" ||
-      ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg' ) ]]
+      ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ]]
     then
       if [[ ${TRAVIS_OS_NAME} == "linux" &&
         ( ${CXX_compiler} != g++* || ${CXX_compiler%g++-} < 7 ) ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -277,6 +277,9 @@ before_install:
   if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
     export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
   fi
+  if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]]; then
+    Coverage=""
+  fi
 - |
   # Install Ninja-build (if not installed)
   if [[ ! -x "$(command -v ninja)" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ git:
 env:
   global:
   # vcpkg
+  - VCPKG_DIR:       $HOME/tools/vcpkg
   - TOOLCHAIN_FILE: "$HOME/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 ##====--------------------------------------------------------------------====##
@@ -343,21 +344,27 @@ before_install:
 - |
   # Download vcpkg
   ( set -euo pipefail
-    git clone --depth=1 --branch=master --quiet \
-      https://github.com/Microsoft/vcpkg.git $HOME/tools/vcpkg
-    mv -f -t ~/tools/vcpkg ~/tools/.cache/vcpkg/* ||
-      echo "No cached files for vcpkg."
+    # Full history clone for rebuild detection.
+    git clone --quiet https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR}
+    mv -f -t ${VCPKG_DIR} ~/tools/.cache/vcpkg/* || echo "No cached files."
   )
-  export PATH=$PATH:$HOME/tools/vcpkg
+  export PATH=$PATH:${VCPKG_DIR}
 - |
   # Install/Update vcpkg
+  cd ${VCPKG_DIR}
   ( set -euxo pipefail
+    VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
+    GENERATE_SRC_HASH="(
+      git log --format=format:\"%H\" --max-count=1 -- toolsrc
+    )"
     if [[ ! -x "$(command -v vcpkg)" ||
-      ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ]]
+      ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ||
+      ( $(eval ${GENERATE_SRC_HASH}) != $(< ${VCPKG_SRC_HASH}) ) ]]
     then
       if [[ ${CC_vcpkg:-} ]];  then eval "CC=${CC_vcpkg}"; fi
       if [[ ${CXX_vcpkg:-} ]]; then eval "CXX=${CXX_vcpkg}"; fi
       bootstrap-vcpkg.sh
+      eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
     fi
   )
 - |
@@ -430,7 +437,8 @@ before_cache:
 - |
   # Select files for caching
   mkdir -p ~/tools/.cache/vcpkg
-  mv -u -t ~/tools/.cache/vcpkg ~/tools/vcpkg/vcpkg ~/tools/vcpkg/installed
+  mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/installed
+  mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg_src_hash
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 # TravisCI build configuration.
 # Continuous integration testing on Linux and OSX. Using GCC, LLVM/Clang and
 # AppleClang. Debug and Release builds, unit tests and codecoverage.
-language: cpp
-
 git:
   depth: 20
   quiet: true
@@ -18,10 +16,10 @@ env:
 # No build matrix, each item in matrix:include is single build configuration.
 #
 # Environment variables:
-# - C_compiler: overwrites default value of CC.
-# - CXX_compiler: overwrites default value of CXX.
 # - CXX_lib: library selection.
 #   - libc++  (Linux only, default on OSX.)
+# - CC/CXX_vcpkg: build vcpkg with a different compiler.
+#   Linux minimum: `g++-7`; OSX minimum: `g++-6`; Or clang-8 (with libc++-8).
 # - CONFIGURATION: specifies the build configuration.
 #   When not set both a Debug and a Release configurations are build in single
 #   job session.
@@ -63,9 +61,9 @@ jobs:
   - name: GCC-9
     stage: "Build & Test Latest"
     env:
-    - C_compiler:   gcc-9
-    - CXX_compiler: g++-9
-    - Coverage:     gcov-9
+    - CC:  gcc-9
+    - CXX: g++-9
+    - Coverage: gcov-9
     addons:
       apt:
         sources:
@@ -76,9 +74,9 @@ jobs:
   - name: GCC-8
     stage: "Build & Test"
     env:
-    - C_compiler:   gcc-8
-    - CXX_compiler: g++-8
-    - Coverage:     gcov-8
+    - CC:  gcc-8
+    - CXX: g++-8
+    - Coverage: gcov-8
     addons:
       apt:
         sources:
@@ -89,9 +87,9 @@ jobs:
   - name: GCC-7
     stage: "Build & Test"
     env:
-    - C_compiler:   gcc-7
-    - CXX_compiler: g++-7
-    - Coverage:     gcov-7
+    - CC:  gcc-7
+    - CXX: g++-7
+    - Coverage: gcov-7
     addons:
       apt:
         sources:
@@ -103,8 +101,9 @@ jobs:
     stage: "Build & Test Latest"
     dist: xenial
     env:
-    - C_compiler:   clang-8
-    - CXX_compiler: clang++-8
+    - CC: clang-8
+    - CXX: clang++-8
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       apt:
@@ -119,8 +118,8 @@ jobs:
     stage: "Build & Test Latest"
     dist: xenial
     env:
-    - C_compiler:   clang-8
-    - CXX_compiler: clang++-8
+    - CC: clang-8
+    - CXX: clang++-8
     - CXX_lib: libc++
     - Coverage: grcov
     addons:
@@ -136,9 +135,10 @@ jobs:
   - name: Clang-7
     stage: "Build & Test"
     dist: xenial # Ships with Clang 7
+    language: cpp
+    compiler: clang
     env:
-    - C_compiler:   clang
-    - CXX_compiler: clang++
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       apt: # vcpkg executable requires GCC 7 or better
@@ -150,9 +150,10 @@ jobs:
   - name: Clang-7 libc++
     dist: xenial
     env:
-    - C_compiler:   clang
-    - CXX_compiler: clang++
+    - CC:  clang
+    - CXX: clang++
     - CXX_lib: libc++
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       apt:
@@ -167,8 +168,9 @@ jobs:
   - name: Clang-6.0
     dist: xenial
     env:
-    - C_compiler: clang-6.0
-    - CXX_compiler: clang++-6.0
+    - CC: clang-6.0
+    - CXX: clang++-6.0
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       apt:
@@ -182,8 +184,9 @@ jobs:
   - name: Clang-5.0
     dist: xenial
     env:
-    - C_compiler: clang-5.0
-    - CXX_compiler: clang++-5.0
+    - CC: clang-5.0
+    - CXX: clang++-5.0
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       apt:
@@ -197,8 +200,9 @@ jobs:
     if: branch =~ /^[Tt]ravis.*$/
     dist: xenial
     env:
-    - C_compiler: clang-4.0
-    - CXX_compiler: clang++-4.0
+    - CC: clang-4.0
+    - CXX: clang++-4.0
+    - CXX_vcpkg: g++-7
     - CONFIGURATION: Debug
     addons:
       apt:
@@ -211,7 +215,9 @@ jobs:
   - name: AppleClang Xcode-10.2
     os: osx
     osx_image: xcode10.2 # AppleClang 10.0.1
+    language: cpp
     env:
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       homebrew:
@@ -223,7 +229,9 @@ jobs:
     if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
     osx_image: xcode10.1 # AppleClang 10.0.0 same compiler as Xcode 10.0
+    language: cpp
     env:
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons:
       homebrew:
@@ -236,7 +244,9 @@ jobs:
     if: branch =~ /^[Tt]ravis.*$/
     os: osx
     osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
+    language: cpp
     env:
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons: &OSX-legacy
       homebrew:
@@ -250,7 +260,9 @@ jobs:
     if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
     osx_image: xcode9 # AppleClang 9.1.0 same compiler in Xcode 9.0, 9.1 and 9.2
+    language: cpp
     env:
+    - CXX_vcpkg: g++-7
     - Coverage: grcov
     addons: *OSX-legacy
 
@@ -264,8 +276,6 @@ before_install:
 - |
   # Setup
   mkdir -p ~/tools && cd ~/tools
-  if [[ ${C_compiler:-} ]]; then   export CC=${C_compiler:?}; fi
-  if [[ ${CXX_compiler:-} ]]; then export CXX=${CXX_compiler:?}; fi
   if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
     export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
   fi
@@ -345,19 +355,14 @@ before_install:
     if [[ ! -x "$(command -v vcpkg)" ||
       ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ]]
     then
-      if [[ ${TRAVIS_OS_NAME} == "linux" &&
-        ( ${CXX_compiler} != g++* || ${CXX_compiler%g++-} < 7 ) ]]
-      then
-        eval "CC=gcc-7 && CXX=g++-7" # Minimum requirement vcpkg on Linux
-      elif [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
-        eval "CC=gcc-7 && CXX=g++-7" # Minimum requirement vcpkg on OSX
-      fi
-      ~/tools/vcpkg/bootstrap-vcpkg.sh
+      if [[ ${CC_vcpkg:-} ]];  then eval "CC=${CC_vcpkg}"; fi
+      if [[ ${CXX_vcpkg:-} ]]; then eval "CXX=${CXX_vcpkg}"; fi
+      bootstrap-vcpkg.sh
     fi
   )
 - |
   # Using libc++
-  if [[ ${CXX_compiler} == clang* && ${CXX_lib:-} ]]; then
+  if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
     FLAGS="-stdlib=${CXX_lib}"
     #if [[ ${CXX_lib} == libc++ ]]; then
     #  FLAGS="${FLAGS} -lc++fs"
@@ -444,7 +449,7 @@ after_success:
     if [[ ${Coverage} == "grcov" ]]; then
       coverage_report="coverage.json"
       flags=("--branch")
-      if [[ ${CXX_compiler:-} == clang* ]]; then flags+=("--llvm"); fi
+      if [[ ${CXX} == clang* ]]; then flags+=("--llvm"); fi
       options=("-s ${Source_Dir:?}")
       options+=("-t coveralls+" "--token unused")
       options+=("--commit-sha ${TRAVIS_COMMIT}")

--- a/.travis.yml
+++ b/.travis.yml
@@ -360,6 +360,9 @@ before_install:
     then
       if [[ ${CC_vcpkg:-} ]];  then eval "CC=${CC_vcpkg}"; fi
       if [[ ${CXX_vcpkg:-} ]]; then eval "CXX=${CXX_vcpkg}"; fi
+      if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
+        export CXXFLAGS="${CXXFLAGS:-} -stdlib=${CXX_lib}"
+      fi
       bootstrap-vcpkg.sh
       eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
     fi
@@ -372,7 +375,7 @@ before_install:
     #  FLAGS="${FLAGS} -lc++fs"
     #  FLAGS="${FLAGS} -lc++experimental"
     #fi
-    export CXXFLAGS="${CXXFLAGS} ${FLAGS}"
+    export CXXFLAGS="${CXXFLAGS:-} ${FLAGS}"
   fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # TravisCI build configuration.
 # Continuous integration testing on Linux and OSX. Using GCC, LLVM/Clang and
 # AppleClang. Debug and Release builds, unit tests and codecoverage.
+language: cpp
+
 git:
   depth: 20
   quiet: true
@@ -136,7 +138,6 @@ jobs:
   - name: Clang-7
     stage: "Build & Test"
     dist: xenial # Ships with Clang 7
-    language: cpp
     compiler: clang
     env:
     - CXX_vcpkg: g++-7
@@ -216,7 +217,6 @@ jobs:
   - name: AppleClang Xcode-10.2
     os: osx
     osx_image: xcode10.2 # AppleClang 10.0.1
-    language: cpp
     env:
     - CXX_vcpkg: g++-7
     - Coverage: grcov
@@ -230,7 +230,6 @@ jobs:
     if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
     osx_image: xcode10.1 # AppleClang 10.0.0 same compiler as Xcode 10.0
-    language: cpp
     env:
     - CXX_vcpkg: g++-7
     - Coverage: grcov
@@ -245,7 +244,6 @@ jobs:
     if: branch =~ /^[Tt]ravis.*$/
     os: osx
     osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
-    language: cpp
     env:
     - CXX_vcpkg: g++-7
     - Coverage: grcov
@@ -261,7 +259,6 @@ jobs:
     if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
     osx_image: xcode9 # AppleClang 9.1.0 same compiler in Xcode 9.0, 9.1 and 9.2
-    language: cpp
     env:
     - CXX_vcpkg: g++-7
     - Coverage: grcov


### PR DESCRIPTION
The vcpkg version number is not regularly updated anymore.
A breaking change required a rebuild. (Microsoft/vcpkg#6946)

Now whenever the source for the vcpkg tool is changed, it will be rebuild.

While vcpkg is being developed this might result in more rebuilds of vcpkg than of the acquired libraries.
The alternative is to only decide to rebuild when a package needs updating.
But that would not have worked with the past situation, where there has not been a package update and the control file format changed.