### PR TITLE
Module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,13 @@ option(CODE_COVERAGE "Enable coverage reporting" OFF)
 ##====--------------------------------------------------------------------====##
 # External CMake definitions
 ##====--------------------------------------------------------------------====##
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Functions
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/add_to_source_file_properties.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/set_precompiled_header.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/subproject_functions.cmake)
+include(add_to_source_file_properties)
+include(set_precompiled_header)
+include(subproject_functions)
 # Properties
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/msvc_warnings_list.cmake)
+include(msvc_warnings_list)
 
 ##====--------------------------------------------------------------------====##
 # The library: Sudoku

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,6 @@ option(CODE_COVERAGE "Enable coverage reporting" OFF)
 # External CMake definitions
 ##====--------------------------------------------------------------------====##
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-# Functions
-include(add_to_source_file_properties)
-include(set_precompiled_header)
-include(subproject_functions)
-# Properties
-include(msvc_warnings_list)
 
 ##====--------------------------------------------------------------------====##
 # The library: Sudoku

--- a/Console/CMakeLists.txt
+++ b/Console/CMakeLists.txt
@@ -1,6 +1,11 @@
 ##====---- fwkSudoku/Console/CMakeLists.txt                           ----====##
 ##
 ##====--------------------------------------------------------------------====##
+include(add_to_source_file_properties)
+include(msvc_warnings_list)
+include(set_precompiled_header)
+include(subproject_functions)
+
 subproject_cmake_minimum_required(3.12)
 
 project(SudokuConsole LANGUAGES CXX)

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -2,6 +2,11 @@
 ## Tests for library Sudoku.
 ##
 ##====--------------------------------------------------------------------====##
+include(add_to_source_file_properties)
+include(msvc_warnings_list)
+include(set_precompiled_header)
+include(subproject_functions)
+
 subproject_cmake_minimum_required(3.12)
 
 project(fwkSudokuTests LANGUAGES CXX)

--- a/cmake/msvc_warnings_list.cmake
+++ b/cmake/msvc_warnings_list.cmake
@@ -15,7 +15,7 @@
 ##====--------------------------------------------------------------------====##
 ## Usage:
 ## ````cmake
-## include(cmake/msvc_warnings_list.cmake)
+## include(msvc_warnings_list)
 ##
 ## # Optionally edited (local only):
 ## list(APPEND MSVC_Extra_Warnings "/wd4715")


### PR DESCRIPTION
Simplify CMake configuration by using the `CMAKE_MODULE_PATH` variable.