### PR TITLE
TravisCI: use the Ubuntu Bionic Beaver image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -242,21 +242,8 @@ jobs:
         - gcc@7 # vcpkg requires gcc-7 or better
         update: true
 
-  - name: AppleClang Xcode-9.4
-    if: branch =~ /^[Tt]ravis.*$/
-    os: osx
-    osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
-    env:
-    - CXX_vcpkg: g++-7
-    - Coverage: grcov
-    addons: &OSX-legacy
-      homebrew:
-        packages:
-        - ninja
-        - gcc@7 # vcpkg requires gcc-7 or better
-        - cmake # Xcode 9.4 and earlier have 3.11.4
-        update: true
-
+  # Note: can not build vcpkg on xcode-9.3/4, missing OSX update on Travis.
+  # Earliest available with C++17 support
   - name: AppleClang Xcode-9
     if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
@@ -264,11 +251,16 @@ jobs:
     env:
     - CXX_vcpkg: g++-7
     - Coverage: grcov
-    addons: *OSX-legacy
+    addons:
+      homebrew:
+        packages:
+        - ninja
+        - gcc@7 # vcpkg requires gcc-6 or better
+        - cmake # Xcode 9.4 and earlier have 3.11.4
+        update: true
 
   allow_failures:
   - name: Clang-4.0 Debug
-  - name: AppleClang Xcode-9.4
 
 ##====--------------------------------------------------------------------====##
 ## Install tools and dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,20 @@ jobs:
         packages:
         - clang-6.0
 
+  - name: Clang-6.0 libc++
+    env:
+    - CC: clang-6.0
+    - CXX: clang++-6.0
+    - CXX_lib: libc++
+    - CXX_vcpkg: g++-7
+    - Coverage: grcov
+    addons:
+      apt:
+        packages:
+        - clang-6.0
+        - libc++-dev # 6.0 on Bionic
+        - libc++abi-dev
+
   - name: Clang-5.0
     env:
     - CC: clang-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
     addons:
       apt:
         sources:
-        - ubuntu-toolchain-r-test
+        - sourceline: ppa:ubuntu-toolchain-r/test
         packages:
         - g++-9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -452,6 +452,7 @@ after_success:
     Build_Dir="${TRAVIS_BUILD_DIR}/build"
     bash_flags=("-n ${TRAVIS_JOB_NAME/ /_}") # Replace space with '_'
     if [[ ${Coverage} == "grcov" ]]; then
+      bash_flags+=("-X gcov") # Disable gcov
       coverage_report="coverage.json"
       flags=("--branch")
       if [[ ${CXX} == clang* ]]; then flags+=("--llvm"); fi
@@ -461,6 +462,7 @@ after_success:
       options+=("--prefix-dir ../") # suppress warning grcov v0.5.1
       grcov ${Build_Dir:?} ${flags[@]} ${options[@]} > ${coverage_report:?}
     elif [[ ${Coverage} == "lcov" ]]; then
+      bash_flags+=("-X gcov") # Disable gcov
       coverage_report="coverage.info"
       lcov --capture --directory ${Build_Dir:?} --output-file coverage.info
       lcov --remove coverage.info '/usr/*' --output-file coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ env:
 
 # Defaults
 os: linux
-dist: xenial
+dist: bionic
 
 # Specify Stage Order and Conditions
 stages:
@@ -84,44 +84,32 @@ jobs:
     - Coverage: gcov-8
     addons:
       apt:
-        sources:
-        - ubuntu-toolchain-r-test
         packages:
         - g++-8
 
-  - name: GCC-7
+  - name: GCC-7 # default on Bionic image
     stage: "Build & Test"
     env:
     - CC:  gcc-7
     - CXX: g++-7
     - Coverage: gcov-7
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
 
   - name: Clang-8
     stage: "Build & Test Latest"
-    dist: xenial
     env:
     - CC: clang-8
     - CXX: clang++-8
-    - CXX_vcpkg: g++-7
+    - CXX_vcpkg: g++
     - Coverage: grcov
     addons:
       apt:
         sources:
-        - llvm-toolchain-xenial-8
-        - ubuntu-toolchain-r-test
+        - llvm-toolchain-bionic-8
         packages:
         - clang-8
-        - g++-7
 
   - name: Clang-8 libc++
     stage: "Build & Test Latest"
-    dist: xenial
     env:
     - CC: clang-8
     - CXX: clang++-8
@@ -130,91 +118,66 @@ jobs:
     addons:
       apt:
         sources:
-        - llvm-toolchain-xenial-8
-        - ubuntu-toolchain-r-test
+        - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
+          key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
         packages:
         - clang-8
         - libc++-8-dev
         - libc++abi-8-dev
 
-  - name: Clang-7
+  - name: Clang-7 # default on Xenial and Bionic images
     stage: "Build & Test"
-    dist: xenial # Ships with Clang 7
     compiler: clang
     env:
-    - CXX_vcpkg: g++-7
+    - CXX_vcpkg: g++ # vcpkg executable requires GCC-7 or better
     - Coverage: grcov
-    addons:
-      apt: # vcpkg executable requires GCC 7 or better
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-7
 
   - name: Clang-7 libc++
-    dist: xenial
     env:
     - CC:  clang
     - CXX: clang++
     - CXX_lib: libc++
-    - CXX_vcpkg: g++-7
+    - CXX_vcpkg: g++
     - Coverage: grcov
     addons:
       apt:
-        sources:
-        - llvm-toolchain-xenial-7
-        - ubuntu-toolchain-r-test
         packages:
-        - g++-7
         - libc++-7-dev
         - libc++abi-7-dev
 
   - name: Clang-6.0
-    dist: xenial
     env:
     - CC: clang-6.0
     - CXX: clang++-6.0
-    - CXX_vcpkg: g++-7
+    - CXX_vcpkg: g++
     - Coverage: grcov
     addons:
       apt:
-        sources:
-        - llvm-toolchain-xenial-6.0
-        - ubuntu-toolchain-r-test
         packages:
         - clang-6.0
-        - g++-7
 
   - name: Clang-5.0
-    dist: xenial
     env:
     - CC: clang-5.0
     - CXX: clang++-5.0
-    - CXX_vcpkg: g++-7
+    - CXX_vcpkg: g++
     - Coverage: grcov
     addons:
       apt:
-        sources:
-        - ubuntu-toolchain-r-test
         packages:
         - clang-5.0
-        - g++-7
 
   - name: Clang-4.0 Debug
     if: branch =~ /^[Tt]ravis.*$/
-    dist: xenial
     env:
     - CC: clang-4.0
     - CXX: clang++-4.0
-    - CXX_vcpkg: g++-7
+    - CXX_vcpkg: g++
     - CONFIGURATION: Debug
     addons:
       apt:
-        sources:
-        - ubuntu-toolchain-r-test
         packages:
         - clang-4.0
-        - g++-7
 
   - name: AppleClang Xcode-10.2
     os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,8 @@ jobs:
     addons:
       apt:
         sources:
-        - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
+        - sourceline:
+            'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
           key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
         packages:
         - clang-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ env:
 # https://libcxx.llvm.org/docs/UsingLibcxx.html
 # Homebrew OSX packages:
 # https://formulae.brew.sh/formula/
+# Xcode compiler list and relation to LLVM:
+# https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
 
 # Defaults
 os: linux

--- a/Console/CMakeLists.txt
+++ b/Console/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
       -Wno-weak-vtables   # exceptions
     >
     $<$<CXX_COMPILER_ID:Clang>:
-      $<$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0>:
+      $<$<OR:$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0>,$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0.1>>:
         -Wno-missing-braces
       >
     >

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -148,7 +148,6 @@ else()
     $<$<CXX_COMPILER_ID:Clang>:
       $<$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0>:
         -Wno-missing-braces
-        -Wno-zero-as-null-pointer-constant
       >
     >
     $<$<CXX_COMPILER_ID:AppleClang>:

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -146,7 +146,7 @@ else()
       -Wno-weak-vtables           # exceptions.h
     >
     $<$<CXX_COMPILER_ID:Clang>:
-      $<$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0>:
+      $<$<OR:$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0>,$<VERSION_EQUAL:$<CXX_COMPILER_VERSION>,5.0.1>>:
         -Wno-missing-braces
       >
     >


### PR DESCRIPTION
Travis has added the `bionic` image, based on Ubuntu 18.04 LTS "Bionic Beaver".

* Use the `bionic` image in all Linux build jobs (replacing `xenial`).
* GCC-7.4 is installed by default. This should save time on apt package updates for most jobs. (GCC-7 or LLVM/clang-8 with libc++ is a minimum requirement to build vcpkg.)
* All compilers except for GCC-9 are available in the default Ubuntu package repository.
  The LLVM/clang-5.0 release is now v5.0.1.
* libc++-6.0 is available on Ubuntu 18.04 LTS.

* Removed testing with Xcode-9.4. The image on Travis is missing updates, required to use GCC.
