### PR TITLE
TravisCI reduce CI round-trip time with workspaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -350,7 +350,9 @@ before_install:
   fi
 - |
   # Temporary fix for image: xcode11 to use GCC.
-  if [[ ${TRAVIS_OSX_IMAGE} == "xcode11" ]]; then
+  if [[ ${TRAVIS_OSX_IMAGE} == "xcode11" &&
+    ( "${CXX_vcpkg:-}" || ${CXX} == g++-* )
+  ]]; then
     sudo installer -pkg \
     /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg\
     -target /

--- a/.travis.yml
+++ b/.travis.yml
@@ -281,7 +281,7 @@ jobs:
 
   # Note: can not build vcpkg on Xcode-9.3/4, missing OSX update on Travis.
   - name: AppleClang Xcode-9.4
-    if: branch =~ /^[Tt]ravis.*$/
+    if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
     osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
     env:
@@ -334,7 +334,6 @@ jobs:
 
   allow_failures:
   - name: Clang-4.0 Debug
-  - name: AppleClang Xcode-9.4
 
 ##====--------------------------------------------------------------------====##
 ## Install tools and dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ dist: bionic
 
 # Specify Stage Order and Conditions
 stages:
+- "Build Dependencies"
 - "Build & Test Latest" # First: (4) builds to run first
 - name: "Build & Test"  # If all succeed build rest
   if: NOT (branch =~ /^[Aa]pp[Vv]eyor.*/)
@@ -69,6 +70,8 @@ jobs:
     stage: "Build & Test Latest"
     env:
     - CMake_version: '"3.15.1 3.14.5 3.13.5 3.12.4 3.12.0"'
+    workspaces:
+      use: Linux
     addons:
       apt:
         sources:
@@ -107,6 +110,8 @@ jobs:
     - CXX: g++-9
     - CMake_version: 3.15.1
     - Coverage: gcov-9
+    workspaces:
+      use: Linux
     addons:
       apt:
         sources:
@@ -120,6 +125,8 @@ jobs:
     - CC:  gcc-8
     - CXX: g++-8
     - Coverage: gcov-8
+    workspaces:
+      use: Linux
     addons:
       apt:
         packages:
@@ -131,14 +138,17 @@ jobs:
     - CC:  gcc-7
     - CXX: g++-7
     - Coverage: gcov-7
+    workspaces:
+      use: Linux
 
   - name: Clang-8
     stage: "Build & Test Latest"
     env:
     - CC: clang-8
     - CXX: clang++-8
-    - CXX_vcpkg: g++
     - Coverage: grcov
+    workspaces:
+      use: Linux
     addons:
       apt:
         sources:
@@ -155,6 +165,8 @@ jobs:
     - CXX: clang++-8
     - CXX_lib: libc++
     - Coverage: grcov
+    workspaces:
+      use: Linux
     addons:
       apt:
         sources:
@@ -170,16 +182,18 @@ jobs:
     stage: "Build & Test"
     compiler: clang
     env:
-    - CXX_vcpkg: g++ # vcpkg executable requires GCC-7 or better
     - Coverage: grcov
+    workspaces:
+      use: Linux
 
   - name: Clang-7 libc++
     env:
     - CC:  clang
     - CXX: clang++
     - CXX_lib: libc++
-    - CXX_vcpkg: g++
     - Coverage: grcov
+    workspaces:
+      use: Linux
     addons:
       apt:
         packages:
@@ -190,8 +204,9 @@ jobs:
     env:
     - CC: clang-6.0
     - CXX: clang++-6.0
-    - CXX_vcpkg: g++
     - Coverage: grcov
+    workspaces:
+      use: Linux
     addons:
       apt:
         packages:
@@ -202,8 +217,9 @@ jobs:
     - CC: clang-6.0
     - CXX: clang++-6.0
     - CXX_lib: libc++
-    - CXX_vcpkg: g++-7
     - Coverage: grcov
+    workspaces:
+      use: Linux
     addons:
       apt:
         packages:
@@ -215,8 +231,9 @@ jobs:
     env:
     - CC: clang-5.0
     - CXX: clang++-5.0
-    - CXX_vcpkg: g++
     - Coverage: grcov
+    workspaces:
+      use: Linux
     addons:
       apt:
         packages:
@@ -227,8 +244,9 @@ jobs:
     env:
     - CC: clang-4.0
     - CXX: clang++-4.0
-    - CXX_vcpkg: g++
     - CONFIGURATION: Debug
+    workspaces:
+      use: Linux
     addons:
       apt:
         packages:
@@ -238,8 +256,9 @@ jobs:
     os: osx
     osx_image: xcode11 # AppleClang 11.0.0
     env:
-    - CXX_vcpkg: g++-9 # present on xcode11 image
     - Coverage: grcov
+    workspaces:
+      use: OSX
 
   - name: AppleClang Xcode-10.2
     os: osx
@@ -247,14 +266,18 @@ jobs:
     env:
     - CXX_vcpkg: g++-8 # present on xcode10.2
     - Coverage: grcov
+    - Coverage: grcov
+    workspaces:
+      use: OSX
 
   - name: AppleClang Xcode-10.1
     if: branch =~ /^(master|[Tt]ravis.*)$/
     os: osx
     osx_image: xcode10.1 # AppleClang 10.0.0 same compiler as Xcode 10.0
     env:
-    - CXX_vcpkg: g++-8 # present on xcode10.1
     - Coverage: grcov
+    workspaces:
+      use: OSX
 
   # Note: can not build vcpkg on Xcode-9.3/4, missing OSX update on Travis.
   - name: AppleClang Xcode-9.4
@@ -262,15 +285,10 @@ jobs:
     os: osx
     osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
     env:
-    - CXX_vcpkg: g++-7
     - Coverage: grcov
-    addons: &OSX-legacy
-      homebrew:
-        packages:
-        - ninja
-        - gcc@7 # vcpkg requires gcc-7 or better
-        - cmake # Xcode 9.4 comes with CMake 3.11.4
-        update: true
+    - CMake_version: '3.12.4' # Xcode 9.4 comes with CMake 3.11.4
+    workspaces:
+      use: OSX
 
   # Earliest available with C++17 support
   - name: AppleClang Xcode-9
@@ -278,9 +296,40 @@ jobs:
     os: osx
     osx_image: xcode9 # AppleClang 9.1.0 same compiler in Xcode 9.0, 9.1 and 9.2
     env:
-    - CXX_vcpkg: g++-7
     - Coverage: grcov
-    addons: *OSX-legacy
+    - CMake_version: '3.12.4'
+    workspaces:
+      use: OSX
+
+  - name: vcpkg for Linux
+    stage: "Build Dependencies"
+    workspaces:
+      create:
+        name: Linux
+        paths:
+        - ~/tools/.cache/vcpkg
+    install: skip
+    before_script: skip
+    script: skip
+    after_script: skip
+    after_success: skip
+
+  - name: vcpkg for OSX
+    workspaces:
+      create:
+        name: OSX
+        paths:
+        - ~/tools/.cache/vcpkg
+    os: osx
+    osx_image: xcode10.2
+    env:
+    - CC:  gcc-8
+    - CXX: g++-8
+    install: skip
+    before_script: skip
+    script: skip
+    after_script: skip
+    after_success: skip
 
   allow_failures:
   - name: Clang-4.0 Debug
@@ -452,7 +501,8 @@ before_install:
   export PATH=$PATH:${VCPKG_DIR}
 - |
   # Install/Update vcpkg
-  cd ${VCPKG_DIR}
+  if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
+    cd ${VCPKG_DIR}
   ( set -euxo pipefail
     VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
     GENERATE_SRC_HASH="(
@@ -470,7 +520,7 @@ before_install:
       bootstrap-vcpkg.sh
       eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
     fi
-  )
+  ); fi
 - |
   # Using libc++
   if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
@@ -541,8 +591,10 @@ before_cache:
 - |
   # Select files for caching
   mkdir -p ~/tools/.cache/vcpkg
-  mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/installed
-  mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg_src_hash
+  if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
+    mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/vcpkg_src_hash
+  fi
+  mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/installed
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -370,6 +370,51 @@ before_install:
     fi
   fi
 - |
+  # Download vcpkg
+  ( set -euo pipefail
+    # Full history clone for rebuild detection.
+    git clone --quiet https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR}
+    mv -f -t ${VCPKG_DIR} ~/tools/.cache/vcpkg/* || echo "No cached files."
+  )
+  export PATH=$PATH:${VCPKG_DIR}
+- |
+  # Install/Update vcpkg
+  if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
+    cd ${VCPKG_DIR}
+  ( set -euxo pipefail
+    VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
+    GENERATE_SRC_HASH="(
+      git log --format=format:\"%H\" --max-count=1 -- toolsrc
+    )"
+    if [[ ! -x "$(command -v vcpkg)" ||
+      ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ||
+      ( $(eval ${GENERATE_SRC_HASH}) != $(< ${VCPKG_SRC_HASH}) ) ]]
+    then
+      if [[ ${CC_vcpkg:-} ]];  then eval "CC=${CC_vcpkg}"; fi
+      if [[ ${CXX_vcpkg:-} ]]; then eval "CXX=${CXX_vcpkg}"; fi
+      if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
+        export CXXFLAGS="${CXXFLAGS:-} -stdlib=${CXX_lib}"
+      fi
+      if [[ ${TRAVIS_OS_NAME} == "osx" && ${CXX} == g++-* ]]; then
+        export LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc"
+      fi
+      bootstrap-vcpkg.sh
+      eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
+    fi
+  ); fi
+- |
+  # Using libc++
+  if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
+    FLAGS="-stdlib=${CXX_lib}"
+    #if [[ ${CXX_lib} == libc++ ]]; then
+    #  FLAGS="${FLAGS} -lc++fs"
+    #  FLAGS="${FLAGS} -lc++experimental"
+    #fi
+    export CXXFLAGS="${CXXFLAGS:-} ${FLAGS}"
+  fi
+
+install:
+- |
   # Install Ninja-build (if not installed)
   if [[ ! -x "$(command -v ninja)" ]]; then
   ( set -euxo pipefail
@@ -494,51 +539,7 @@ before_install:
       function cmake { command /usr/bin/cmake $@; }
     fi
   fi
-- |
-  # Download vcpkg
-  ( set -euo pipefail
-    # Full history clone for rebuild detection.
-    git clone --quiet https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR}
-    mv -f -t ${VCPKG_DIR} ~/tools/.cache/vcpkg/* || echo "No cached files."
-  )
-  export PATH=$PATH:${VCPKG_DIR}
-- |
-  # Install/Update vcpkg
-  if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
-    cd ${VCPKG_DIR}
-  ( set -euxo pipefail
-    VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
-    GENERATE_SRC_HASH="(
-      git log --format=format:\"%H\" --max-count=1 -- toolsrc
-    )"
-    if [[ ! -x "$(command -v vcpkg)" ||
-      ( $(vcpkg update) == 'Warning: Different source'*'for vcpkg'* ) ||
-      ( $(eval ${GENERATE_SRC_HASH}) != $(< ${VCPKG_SRC_HASH}) ) ]]
-    then
-      if [[ ${CC_vcpkg:-} ]];  then eval "CC=${CC_vcpkg}"; fi
-      if [[ ${CXX_vcpkg:-} ]]; then eval "CXX=${CXX_vcpkg}"; fi
-      if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
-        export CXXFLAGS="${CXXFLAGS:-} -stdlib=${CXX_lib}"
-      fi
-      if [[ ${TRAVIS_OS_NAME} == "osx" && ${CXX} == g++-* ]]; then
-        export LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc"
-      fi
-      bootstrap-vcpkg.sh
-      eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
-    fi
-  ); fi
-- |
-  # Using libc++
-  if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
-    FLAGS="-stdlib=${CXX_lib}"
-    #if [[ ${CXX_lib} == libc++ ]]; then
-    #  FLAGS="${FLAGS} -lc++fs"
-    #  FLAGS="${FLAGS} -lc++experimental"
-    #fi
-    export CXXFLAGS="${CXXFLAGS:-} ${FLAGS}"
-  fi
 
-install:
 - vcpkg install ms-gsl
 - vcpkg install gtest
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ jobs:
     osx_image: xcode10.2 # AppleClang 10.0.1
     env:
     - CMake_version: '"3.15.1 3.14.5 3.13.5 3.12.4 3.12.0"'
-    - CXX_vcpkg: g++-8 # present on xcode10.2
+    workspaces:
+      use: OSX
     script:
     - |
       cd ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -325,6 +325,7 @@ jobs:
     env:
     - CC:  gcc-8
     - CXX: g++-8
+    - MACOSX_DEPLOYMENT_TARGET: '10.12' # minimum supported: xcode9 image
     install: skip
     before_script: skip
     script: skip
@@ -516,6 +517,9 @@ before_install:
       if [[ ${CXX_vcpkg:-} ]]; then eval "CXX=${CXX_vcpkg}"; fi
       if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
         export CXXFLAGS="${CXXFLAGS:-} -stdlib=${CXX_lib}"
+      fi
+      if [[ ${TRAVIS_OS_NAME} == "osx" && ${CXX} == g++-* ]]; then
+        export LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc"
       fi
       bootstrap-vcpkg.sh
       eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}


### PR DESCRIPTION
https://docs.travis-ci.com/user/using-workspaces/

* Building vcpk in a dedicated stage (A Linux and an macOS version) and use it for all jobs.
No need to install GCC on the macOS  systems, thus getting rid of the Homebrew update steps.
Ninja and CMake use the already present installers where required.

  Reduced CI round-trip time:
Cache present: 1:08 -> 0:54 hours
No Cache: 1:50 -> 1:03 hours

* moved the installations for Ninja, CMake and Mozilla/grcov to the `install` step.