### PR TITLE
Restore CI-tests with LLVM/clang-cl

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,8 @@ skip_commits:
 #                  Ninja - requires CMake generator
 #                  MSBuild_Solution - use Visual Studio project configurations
 # TOOLSET          (default empty) - set to image default or by configuration
-#                  llvm, v141, v140, v140_xp
+#                  MSBuild only.
+#                  When installed: ClangCL, v142, llvm, v141, v140, v140_xp
 ##====-----------------
 ## Create_Matrix
 image:
@@ -200,11 +201,6 @@ init:
       $out += "Build system:        $env:BUILDSYSTEM"
       if ($env:NINJA_TAG) { $out +=": $env:NINJA_TAG" }
     }; Write-Output "$out"
-- ps: |
-    if (! $env:TOOLSET -and $env:CONFIGURATION -match "^LLVM_.*") {
-      $env:TOOLSET = "llvm"
-      $env:CONFIGURATION = $env:CONFIGURATION -replace "^LLVM_",""
-    }
 
 ##====--------------------------------------------------------------------====##
 ## Install tools and dependencies
@@ -222,6 +218,15 @@ install:
 
 ##====--------------------------------------------------------------------====##
 before_build:
+- ps: |
+    if (! $env:TOOLSET -and $env:CONFIGURATION -match "^LLVM_.*") {
+      if ("$env:APPVEYOR_BUILD_WORKER_IMAGE" -match "Visual Studio 2017") {
+        $env:TOOLSET = "llvm"
+      } else {
+        $env:TOOLSET = "ClangCL"
+      }
+      $env:CONFIGURATION = $env:CONFIGURATION -replace "^LLVM_",""
+    }
 - ps: |
     if ("$env:BUILDSYSTEM" -eq "Ninja") {
       $GeneratorFlags = '-k 10'
@@ -252,7 +257,7 @@ before_build:
         $CMakeGenFlags = "-G `"$Generator`" -A $Architecture"
       }
     }
-    if ("$env:TOOLSET" -eq "llvm") {
+    if ("$env:TOOLSET" -match "llvm|ClangCL") {
       $env:CC  = "clang-cl"
       $env:CXX = "clang-cl"
       $env:CFLAGS   = "$env:CFLAGS -Werror"


### PR DESCRIPTION
Fixing the issue created in: d28c0943ca4056f72f39c6f8069748b200a049e2

Adding initial support for the optional clang-cl toolset integrated in VS2019 since v16.2.
https://devblogs.microsoft.com/cppblog/clang-llvm-support-for-msbuild-projects/

And using the LLVM toolchain extension for the VS2017 image.