### PR TITLE
Add clang-tidy to CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,62 +1,62 @@
-##===--	./.clang-format - Clang-Format configuration					--===##
+##====---- ./.clang-format - Clang-Format configuration               ----====##
 ##
-##	For the Sudoku project, learning cpp
-##===---------------------------------------------------------------------===##
-##	Documentation:
-##		https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+##    For the Sudoku project, learning cpp
+##====--------------------------------------------------------------------====##
+##    Documentation:
+##        https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 ##
-##	Disable locally:
-##		// clang-format off
-##		...
-##		// clang-format on
-##===---------------------------------------------------------------------===##
+##    Disable locally:
+##        // clang-format off
+##        ...
+##        // clang-format on
+##====--------------------------------------------------------------------====##
 ##
-##	TOC
-##	- Sizes
-##	- Comments
-##	- Include
-##	- Namespace
-##	- Template
-##	- Using
-##	- Blocks
-##		-Single-Line Statements
-##	- Braces
-##	- Functions
-##	- Constructors
-##	- Operators
-##	- Strings
-##	- Penalties
-##	Languages
+## TOC
+## - Sizes
+## - Comments
+## - Include
+## - Namespace
+## - Template
+## - Using
+## - Blocks
+##   -Single-Line Statements
+## - Braces
+## - Functions
+## - Constructors
+## - Operators
+## - Strings
+## - Penalties
+## - Languages
 ##
 
 ---
-#	For starters use defaults from the LLVM style
-#	(required since the complete rule set is needed)
-BasedOnStyle:					LLVM
+# For starters use defaults from the LLVM style
+# (required since the complete rule set is needed)
+BasedOnStyle: LLVM
 
-##	Sizes
-UseTab:							ForContinuationAndIndentation
-TabWidth:						4
-IndentWidth:					4
-ColumnLimit:					80
-MaxEmptyLinesToKeep:			2
-ContinuationIndentWidth:		4
-IndentCaseLabels:				false
-IndentPPDirectives:				None
-AccessModifierOffset:			-4
+## Sizes
+UseTab: ForContinuationAndIndentation
+TabWidth:                4
+IndentWidth:             4
+ColumnLimit:             80
+MaxEmptyLinesToKeep:     2
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+IndentPPDirectives: None
+AccessModifierOffset: -4
 # public: or private: etc.
 
-##	Comments
-ReflowComments:					true
-SpacesBeforeTrailingComments:	1
-AlignTrailingComments:			true
-#CommentPragmas:				
+## Comments
+ReflowComments:               true
+SpacesBeforeTrailingComments: 1
+AlignTrailingComments:        true
+#CommentPragmas:
 
-##	Include
-# #include <xxx>		STL includes
-# #include <xxx.h>	library includes
-# #include "xxx.h"	local project includes
-# 
+## Include
+# #include <xxx>      STL includes
+# #include <xxx.h>    library includes
+# #include "xxx.h"    local project includes
+#
 # Order: (alphabetic within each)
 # Headers should not depend upon other headers being included first.
 #
@@ -67,144 +67,144 @@ AlignTrailingComments:			true
 #   2. Local components     // if used "..."
 #   3. External components  // <../*.h>
 #   4. libraries            //
-#   5. STL data-structures  // ! 
+#   5. STL data-structures  // !
 #   6. STL other            // ! add all used!
 #   7. Forward declaration  // *.fwd.h for recursive external definitions
 #   8. macros files         // like cassert
-IncludeBlocks:      Preserve
-SortIncludes:       true
+IncludeBlocks: Preserve
+SortIncludes: true
 IncludeIsMainRegex: '(_test)?'
 IncludeCategories:
-  - Regex:    '^"((P|p)recompiled|stdafx)'
-    Priority: -1
-  - Regex:    '^<(gtest|gmock|catch)'
-    Priority: 1
-  - Regex:    '.*\.fwd\.h"$'
-    Priority: 7
-  - Regex:    '^"'
-    Priority: 2
-  - Regex:    '^<(abseil|boost|gsl)'
-    Priority: 4
-  - Regex:    '.+(/|\\).+\.h(pp)?>$'
-    Priority: 3
-  - Regex:    '^<(array|vector|deque|stack|queue|string(_view)?|(.+_)?list|(unordered_)?(set|map)|bitset|tuple|optional|variant|any)>'
-    Priority: 5
-  - Regex:    '^<c(assert|errno|std(lib|int|def)|limits|float|fenv|inttypes|signal)>'
-    Priority: 8
-  - Regex:    '^<[a-z/\\_]+>'
-    Priority: 6
-  - Regex:    '.*'
-    Priority: 10
+- Regex:    '^"((P|p)recompiled|stdafx)'
+  Priority: -1
+- Regex:    '^<(gtest|gmock|catch)'
+  Priority: 1
+- Regex:    '.*\.fwd\.h"$'
+  Priority: 7
+- Regex:    '^"'
+  Priority: 2
+- Regex:    '^<(abseil|boost|gsl)'
+  Priority: 4
+- Regex:    '.+(/|\\).+\.h(pp)?>$'
+  Priority: 3
+- Regex:    '^<(array|vector|deque|stack|queue|string(_view)?|(.+_)?list|(unordered_)?(set|map)|bitset|tuple|optional|variant|any)>'
+  Priority: 5
+- Regex:    '^<c(assert|errno|std(lib|int|def)|limits|float|fenv|inttypes|signal)>'
+  Priority: 8
+- Regex:    '^<[a-z/\\_]+>'
+  Priority: 6
+- Regex:    '.*'
+  Priority: 10
 
-##	Namespace
-NamespaceIndentation:			Inner
-CompactNamespaces:				true
-FixNamespaceComments:			true
+## Namespace
+NamespaceIndentation: Inner
+CompactNamespaces: true
+FixNamespaceComments: true
 
-##	Template
-AlwaysBreakTemplateDeclarations:	true
-SpaceAfterTemplateKeyword:			false
+## Template
+AlwaysBreakTemplateDeclarations: true
+SpaceAfterTemplateKeyword: false
 
-##	Using
-SortUsingDeclarations:			false
+## Using
+SortUsingDeclarations: false
 
 ## Blocks
-KeepEmptyLinesAtTheStartOfBlocks:	false
-#BreakBeforeBraces:				Allman
-BreakBeforeBraces:				Custom
+KeepEmptyLinesAtTheStartOfBlocks: false
+#BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterNamespace:				true
-  SplitEmptyNamespace:			true
-  AfterClass:					true
-  AfterStruct:					true
-  AfterUnion:					true
-  SplitEmptyRecord:				true
-  AfterEnum:					false
-  AfterFunction:				true
-  SplitEmptyFunction:			true
-#Clang 6  AfterExternBlock:		true
-  AfterControlStatement:		true
-  BeforeCatch:					true
-  BeforeElse:					true
-  IndentBraces:					false
+  AfterNamespace:        true
+  SplitEmptyNamespace:   true
+  AfterClass:            true
+  AfterStruct:           true
+  AfterUnion:            true
+  SplitEmptyRecord:      true
+  AfterEnum:             false
+  AfterFunction:         true
+  SplitEmptyFunction:    true
+  AfterExternBlock:      true # Clang 6
+  AfterControlStatement: true
+  BeforeCatch:           true
+  BeforeElse:            true
+  IndentBraces:          false
 
-###	Single-Line Statements
-AllowShortBlocksOnASingleLine:			false
-AllowShortFunctionsOnASingleLine:		Inline
-AllowShortIfStatementsOnASingleLine:	true
-AllowShortLoopsOnASingleLine:			false
-AllowShortCaseLabelsOnASingleLine:		true
+### Single-Line Statements
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
 
-##	Braces
-SpacesInAngles:					false
-SpaceAfterCStyleCast:			false
-SpacesInCStyleCastParentheses:	false
-SpacesInContainerLiterals:		false
-SpaceBeforeParens:				ControlStatements
-SpacesInParentheses:			false
-SpaceInEmptyParentheses:		false
-SpacesInSquareBrackets:			false
-Cpp11BracedListStyle:			true
-#	if false always spaces in { dd }
+## Braces
+SpacesInAngles:                false
+SpaceAfterCStyleCast:          false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals:     false
+SpaceBeforeParens:             ControlStatements
+SpacesInParentheses:           false
+SpaceInEmptyParentheses:       false
+SpacesInSquareBrackets:        false
+Cpp11BracedListStyle:          true
+# if false always spaces in { dd }
 
 ## Declarations
-AlignConsecutiveDeclarations:	false
+AlignConsecutiveDeclarations: false
 
-##	Functions
-IndentWrappedFunctionNames:		true
-#	BinPack: if false, all on same line, or one line each
-BinPackArguments:				false
-BinPackParameters:				false
-AlignAfterOpenBracket:			AlwaysBreak
-AllowAllParametersOfDeclarationOnNextLine:	true
-AlwaysBreakAfterReturnType:		None
-#	None= uses PenaltyReturnTypeOnItsOwnLine
+## Functions
+IndentWrappedFunctionNames: true
+# BinPack: if false, all on same line, or one line each
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: true
+AlwaysBreakAfterReturnType: None
+# None= uses PenaltyReturnTypeOnItsOwnLine
 
-##	Constructors
-ConstructorInitializerIndentWidth:	4
-ConstructorInitializerAllOnOneLineOrOnePerLine:	false
-BreakConstructorInitializers:	BeforeColon
+## Constructors
+ConstructorInitializerIndentWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+BreakConstructorInitializers: BeforeColon
 
-##	Operators
-AlignOperands:					true
-AlignConsecutiveAssignments:	true
-SpaceBeforeAssignmentOperators:	true
+## Operators
+AlignOperands: true
+AlignConsecutiveAssignments: true
+SpaceBeforeAssignmentOperators: true
 
-BreakBeforeBinaryOperators:		None
-BreakBeforeInheritanceComma:	false
-BreakBeforeTernaryOperators:	true
+BreakBeforeBinaryOperators: None
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
 
-DerivePointerAlignment:			false
-PointerAlignment:				Left
+DerivePointerAlignment: false
+PointerAlignment: Left
 
-##	Strings
-BreakStringLiterals:				true
-AlignEscapedNewlines:				Right
-AlwaysBreakBeforeMultilineStrings:	true
+## Strings
+BreakStringLiterals: true
+AlignEscapedNewlines: Right
+AlwaysBreakBeforeMultilineStrings: true
 
-##	Penalties:
-PenaltyExcessCharacter:			1000000
-PenaltyBreakAssignment:			2
-PenaltyBreakBeforeFirstCallParameter:	19
-PenaltyBreakComment:			30
-PenaltyBreakFirstLessLess:		120
-PenaltyBreakString:				1000
-PenaltyReturnTypeOnItsOwnLine:	60
+## Penalties:
+PenaltyExcessCharacter: 1000000
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 30
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyReturnTypeOnItsOwnLine: 60
 
 ---
-Language:						Cpp
-DisableFormat:					false
+Language:      Cpp
+DisableFormat: false
 
 # Language standard, using LLVM setting, it might get updated
-#Standard:						Cpp11
+#Standard:      Cpp11
 ---
-Language:						Java
-DisableFormat:					false
+Language:      Java
+DisableFormat: false
 ---
-Language:						JavaScript
-DisableFormat:					false
+Language:      JavaScript
+DisableFormat: false
 ---
-Language:						ObjC
-DisableFormat:					false
+Language:      ObjC
+DisableFormat: false
 
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -51,6 +51,7 @@ Checks:
   -llvm-namespace-comment,
   misc-*,
   modernize-*,
+  -modernize-use-trailing-return-type,
   -mpi-*,
   -objc-*,
   performance-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,7 @@
 ##  Foo(int param); // NOLINT
 ##
 ##  // Silence only the specified checks for the line
-##  Foo(double param); // NOLINT(google-explicit-constructor, google-runtime-int)
+##  Foo(double param); // NOLINT(google-explicit-constructor,google-runtime-int)
 ##
 ##  // Silence only the specified diagnostics for the next line
 ##  // NOLINTNEXTLINE(google-explicit-constructor, google-runtime-int)
@@ -22,10 +22,10 @@
 ## Please, keep sorted by name.
 #
 
+---
 HeaderFilterRegex: Sudoku|Console[\\\/].*
 FormatStyle: file
-Checks:
- '*,
+Checks: '*,
   abseil-*,
   -android-*,
   boost-*,
@@ -65,23 +65,25 @@ Checks:
   -ziron-*'
 
 CheckOptions:
-  - key:   bugprone-argument-comment.StrictMode
-    value: '1'
-  - key:   bugprone-assert-side-effect.CheckFunctionCalls
-    value: '0'
-  - key:   bugprone-suspicious-enum-usage.StrictMode
-    value: '1'
-  - key:   portability-simd-intrinsics.Suggest
-    value: '1'
-  - key:   readability-braces-around-statements.ShortStatementLines
-    value: '3'
-  - key:   readability-function-size.BranchThreshold
-    value: '-1'
-  - key:   readability-function-size.LineThreshold
-    value: '-1'
-  - key:   readability-function-size.NestingThreshold
-    value: '-1'
-  - key:   readability-function-size.ParameterThreshold
-    value: '-1'
-  - key:   readability-function-size.StatementThreshold
-    value: '800'
+- key:   bugprone-argument-comment.StrictMode
+  value: '1'
+- key:   bugprone-assert-side-effect.CheckFunctionCalls
+  value: '0'
+- key:   bugprone-suspicious-enum-usage.StrictMode
+  value: '1'
+- key:   portability-simd-intrinsics.Suggest
+  value: '1'
+- key:   readability-braces-around-statements.ShortStatementLines
+  value: '3'
+- key:   readability-function-size.BranchThreshold
+  value: '-1'
+- key:   readability-function-size.LineThreshold
+  value: '-1'
+- key:   readability-function-size.NestingThreshold
+  value: '-1'
+- key:   readability-function-size.ParameterThreshold
+  value: '-1'
+- key:   readability-function-size.StatementThreshold
+  value: '800'
+
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,8 @@
 ## Please, keep sorted by name.
 #
 
-HeaderFilterRegex: 'Sudoku[\\\/].*'
+HeaderFilterRegex: Sudoku|Console[\\\/].*
+FormatStyle: file
 Checks:
  '*,
   abseil-*,

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
 #   - lcov:  GNU tool, mostly redundant by Codecov's bash script.
 #   - *: if an executable on the PATH, like: gcov-6, run by the bash script.
 #   - any other value runs the bash script in default mode. (I.e. true)
+# - CMAKE_CXX_CLANG_TIDY: command to execute clang-tidy.
 #
 ## Toolchain installation information:
 # https://docs.travis-ci.com/user/installing-dependencies/
@@ -103,6 +104,25 @@ jobs:
       ( set -eu
         for CMAKE in ${CMAKE_path[@]}; do test_CMake_generate $CMAKE; done
       )
+
+  - name: Clang-Tidy
+    stage: "Build & Test"
+    env:
+    - CC: clang-9
+    - CXX: clang++-9
+    - CMAKE_CXX_CLANG_TIDY: '"clang-tidy-9;--warnings-as-errors=*"'
+    - CONFIGURATION: Debug
+    workspaces:
+      use: Linux
+    addons:
+      apt:
+        sources:
+        - sourceline:
+            'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+          key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
+        packages:
+        - clang-9
+        - clang-tidy-9
 
   - name: GCC-9
     stage: "Build & Test Latest"
@@ -372,6 +392,7 @@ jobs:
 
   allow_failures:
   - name: Clang-4.0 Debug
+  - name: Clang-Tidy
 
 ##====--------------------------------------------------------------------====##
 ## Install tools and dependencies
@@ -607,6 +628,9 @@ before_script:
   CMakeGenFlags+=("-DCMAKE_BUILD_TYPE=${CONFIGURATION:-Debug}")
   CMakeGenFlags+=("-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE:?}")
   CMakeGenFlags+=("-DCODE_COVERAGE=${coverage_bool:?}")
+  if [[ ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
+    CMakeGenFlags+=("-DCMAKE_CXX_CLANG_TIDY=${CMAKE_CXX_CLANG_TIDY}")
+  fi
   CMakeGenFlags+=(-Wdev -Werror=dev --warn-uninitialized)
   echo ${CMakeGenFlags[@]}
   if [[ ! ${CONFIGURATION:-} ]]; then
@@ -614,6 +638,9 @@ before_script:
     CMakeGenFlags2=("-G Ninja")
     CMakeGenFlags2+=("-DCMAKE_BUILD_TYPE=Release")
     CMakeGenFlags2+=("-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE:?}")
+    if [[ ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
+      CMakeGenFlags2+=("-DCMAKE_CXX_CLANG_TIDY=${CMAKE_CXX_CLANG_TIDY}")
+    fi
     CMakeGenFlags2+=(-Wdev -Werror=dev --warn-uninitialized)
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 ##====--------------------------------------------------------------------====##
 ## Define Build Configurations
-# No build matrix, each item in matrix:include is single build configuration.
+# No build matrix, each item in jobs:include is a single build configuration.
 #
 # Environment variables:
 # - CXX_lib: library selection.
@@ -581,7 +581,7 @@ install:
     # $1: cmake or full path to cmake
     if [[ "$1" == "cmake" || -x "$(command -v $1)" && "$1" =~ .*cmake$ ]]; then
       echo "----------------"
-      $1 ${CMakeGenFlags[@]:?} ..
+      $1 ${CMakeGenFlags1[@]:?} ..
       rm ./* -rf
       if [[ ${B_REL:-} ]]; then echo "Configuration = Release"
         $1 ${CMakeGenFlags2[@]:?} ..
@@ -628,29 +628,25 @@ before_script:
   export CFLAGS="${CFLAGS} -Werror"
   export CXXFLAGS="${CXXFLAGS} -Werror"
 - |
-  CMakeGenFlags=("-G Ninja")
-  CMakeGenFlags+=("-DCMAKE_BUILD_TYPE=${CONFIGURATION:-Debug}")
-  CMakeGenFlags+=("-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE:?}")
-  CMakeGenFlags+=("-DCODE_COVERAGE=${coverage_bool:?}")
+  # CMake parameters
+  CMakeGenFlags1=("-G Ninja -DCMAKE_BUILD_TYPE=${CONFIGURATION:-Debug}")
+  CMakeGenFlags1+=("-DCODE_COVERAGE=${coverage_bool:?}")
+  SharedGenFlags+=("-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE:?}")
   if [[ ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
-    CMakeGenFlags+=("-DCMAKE_CXX_CLANG_TIDY=${CMAKE_CXX_CLANG_TIDY}")
+    SharedGenFlags+=("-DCMAKE_CXX_CLANG_TIDY=${CMAKE_CXX_CLANG_TIDY}")
   fi
-  CMakeGenFlags+=(-Wdev -Werror=dev --warn-uninitialized)
-  echo ${CMakeGenFlags[@]}
+  SharedGenFlags+=(-Wdev -Werror=dev --warn-uninitialized)
+  CMakeGenFlags1+=(${SharedGenFlags[@]})
+  echo ${CMakeGenFlags1[@]}
   if [[ ! ${CONFIGURATION:-} ]]; then
     B_REL="Build both Debug and Release configurations"
-    CMakeGenFlags2=("-G Ninja")
-    CMakeGenFlags2+=("-DCMAKE_BUILD_TYPE=Release")
-    CMakeGenFlags2+=("-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE:?}")
-    if [[ ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
-      CMakeGenFlags2+=("-DCMAKE_CXX_CLANG_TIDY=${CMAKE_CXX_CLANG_TIDY}")
-    fi
-    CMakeGenFlags2+=(-Wdev -Werror=dev --warn-uninitialized)
+    CMakeGenFlags2=("-G Ninja -DCMAKE_BUILD_TYPE=Release")
+    CMakeGenFlags2+=(${SharedGenFlags[@]})
   fi
 
 script:
 - cd ./build
-- cmake ${CMakeGenFlags[@]:?} ..
+- cmake ${CMakeGenFlags1[@]:?} ..
 - cmake --build . --config ${CONFIGURATION:-Debug} -- ${GeneratorFlags}
 - |
   if [[ ! ${CMAKE_CXX_CLANG_TIDY:-} ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -443,7 +443,7 @@ before_install:
   # Install/Update vcpkg
   if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
     cd ${VCPKG_DIR}
-  ( set -euxo pipefail
+  ( set -euo pipefail
     VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
     GENERATE_SRC_HASH="(
       git log --format=format:\"%H\" --max-count=1 -- toolsrc
@@ -479,7 +479,7 @@ install:
 - |
   # Install Ninja-build (if not installed)
   if [[ ! -x "$(command -v ninja)" ]]; then
-  ( set -euxo pipefail
+  ( set -euo pipefail
     NINJA_VER="v1.9.0"
     if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
       file_name="ninja-linux.zip"
@@ -508,7 +508,7 @@ install:
 - |
   # Install Mozilla/grcov
   if [[ ${Coverage:-} && ${Coverage} == "grcov" ]]; then
-  ( set -euxo pipefail
+  ( set -euo pipefail
     if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
       GRCOV_TAG="v0.5.3"
       GRCOV_SHA512="3d7f1fbfa11949d7ba57a507eeee4a1ed24580d2ac7aea8b6928324345d4fb4fc41856598169f9dbd860897537ec97e4587c65127d428bd91461f4815c8c2193"
@@ -687,7 +687,7 @@ after_success:
   # Code coverage
   cd "${TRAVIS_BUILD_DIR}/build"
   if [[ ${Coverage:-} ]]; then
-  ( set -euxo pipefail
+  ( set -euo pipefail
     Source_Dir="${TRAVIS_BUILD_DIR}"
     Build_Dir="${TRAVIS_BUILD_DIR}/build"
     bash_flags=("-n ${TRAVIS_JOB_NAME/ /_}") # Replace space with '_'

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,14 @@ dist: bionic
 stages:
 - "Build Dependencies"
 - "Build & Test Latest" # First: (4) builds to run first
+- name: "Validation"
 - name: "Build & Test"  # If all succeed build rest
   if: NOT (branch =~ /^[Aa]pp[Vv]eyor.*/)
 
 jobs:
   include:
   - name: CMake versions
-    stage: "Build & Test Latest"
+    stage: "Validation"
     env:
     - CMake_version: '"3.15.2 3.14.5 3.13.5 3.12.4 3.12.0"'
     workspaces:
@@ -91,7 +92,7 @@ jobs:
       )
 
   - name: CMake versions
-    stage: "Build & Test"
+    stage: "Validation"
     os: osx
     osx_image: xcode10.3 # AppleClang 10.0.1
     env:
@@ -106,7 +107,7 @@ jobs:
       )
 
   - name: Clang-Tidy
-    stage: "Build & Test"
+    stage: "Validation"
     env:
     - CC: clang-9
     - CXX: clang++-9
@@ -311,6 +312,7 @@ jobs:
         - clang-4.0
 
   - name: AppleClang Xcode-11.0
+    stage: "Build & Test Latest"
     os: osx
     osx_image: xcode11 # AppleClang 11.0.0
     env:
@@ -319,6 +321,7 @@ jobs:
       use: OSX
 
   - name: AppleClang Xcode-10.3
+    stage: "Build & Test"
     os: osx
     osx_image: xcode10.3 # AppleClang 10.0.1 same compiler as Xcode10.2
     env:
@@ -373,6 +376,7 @@ jobs:
     after_success: skip
 
   - name: vcpkg for OSX
+    stage: "Build Dependencies"
     workspaces:
       create:
         name: OSX

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 #   - lcov:  GNU tool, mostly redundant by Codecov's bash script.
 #   - *: if an executable on the PATH, like: gcov-6, run by the bash script.
 #   - any other value runs the bash script in default mode. (I.e. true)
-# - CMAKE_CXX_CLANG_TIDY: command to execute clang-tidy.
+# - CMAKE_CXX_CLANG_TIDY: command to execute clang-tidy. Disables unit-tests.
 #
 ## Toolchain installation information:
 # https://docs.travis-ci.com/user/installing-dependencies/
@@ -648,14 +648,24 @@ script:
 - cd ./build
 - cmake ${CMakeGenFlags[@]:?} ..
 - cmake --build . --config ${CONFIGURATION:-Debug} -- ${GeneratorFlags}
-- ctest -j $(nproc) --output-on-failure
-- cd ../build2
+- |
+  if [[ ! ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
+    ctest -j $(nproc) --output-on-failure
+  fi
+- |
+  if [[ ${B_REL:-} ]]; then
+    cd ../build2
+    echo ${CMakeGenFlags2[@]:?}
+  fi
 - if [[ ${B_REL:-} ]]; then cmake ${CMakeGenFlags2[@]:?} ..; fi
 - |
   if [[ ${B_REL:-} ]]; then
     cmake --build . --config Release -- ${GeneratorFlags}
   fi
-- if [[ ${B_REL:-} ]]; then ctest -j $(nproc) --output-on-failure; fi
+- |
+  if [[ ${B_REL:-} && ! ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
+    ctest -j $(nproc) --output-on-failure
+  fi
 
 ##====--------------------------------------------------------------------====##
 before_cache:

--- a/Console/Console.h
+++ b/Console/Console.h
@@ -62,8 +62,8 @@ public:
 	delimiter d;
 
 private:
-	int charsize(int value) const;
-	int charsize(int, int length) const; // recursion
+	[[nodiscard]] int charsize(int value) const;
+	[[nodiscard]] int charsize(int, int length) const; // recursion
 	//	bool Format::find_option(const Board<std::set<int>>&, Location, int
 	// value);
 	// format elem

--- a/Sudoku/Sudoku/Board.h
+++ b/Sudoku/Sudoku/Board.h
@@ -82,11 +82,11 @@ public:
 	}
 	// Checked
 	constexpr T& at(Location);
-	constexpr T const& at(Location) const;
+	[[nodiscard]] constexpr T const& at(Location) const;
 	constexpr T& at(index row, index col);
-	constexpr T const& at(index row, index col) const;
+	[[nodiscard]] constexpr T const& at(index row, index col) const;
 	[[deprecated]] T& at(index elem);
-	[[deprecated]] const T& at(index elem) const;
+	[[deprecated, nodiscard]] const T& at(index elem) const;
 	// Unchecked
 	constexpr T& operator[](Location) noexcept;
 	constexpr T const& operator[](Location) const noexcept;
@@ -102,39 +102,48 @@ public:
 	// Iterators
 	constexpr iterator begin() noexcept;
 	constexpr iterator end() noexcept;
-	constexpr const_iterator cbegin() const noexcept;
-	constexpr const_iterator cend() const noexcept;
-	constexpr const_iterator begin() const noexcept { return cbegin(); }
-	constexpr const_iterator end() const noexcept { return cend(); }
+	[[nodiscard]] constexpr const_iterator cbegin() const noexcept;
+	[[nodiscard]] constexpr const_iterator cend() const noexcept;
+	[[nodiscard]] constexpr const_iterator begin() const noexcept
+	{
+		return cbegin();
+	}
+	[[nodiscard]] constexpr const_iterator end() const noexcept
+	{
+		return cend();
+	}
 	constexpr reverse_iterator rbegin() noexcept;
 	constexpr reverse_iterator rend() noexcept;
-	constexpr const_reverse_iterator crbegin() const noexcept;
-	constexpr const_reverse_iterator crend() const noexcept;
-	constexpr const_reverse_iterator rbegin() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept;
+	[[nodiscard]] constexpr const_reverse_iterator crend() const noexcept;
+	[[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return crbegin();
 	}
-	constexpr const_reverse_iterator rend() const noexcept { return crend(); }
+	[[nodiscard]] constexpr const_reverse_iterator rend() const noexcept
+	{
+		return crend();
+	}
 
 	// Sections
 	// clang-format off
 	Row row(index id) noexcept         { return Row(*this, id); }
-	constexpr const_Row   row(index id) const noexcept
+	[[nodiscard]] constexpr const_Row   row(index id) const noexcept
 									   { return const_Row(*this, id); }
 	Row row(Location loc) noexcept     { return Row(*this, loc); }
-	constexpr const_Row   row(Location loc) const noexcept
+	[[nodiscard]] constexpr const_Row   row(Location loc) const noexcept
 									   { return const_Row(*this, loc); }
 	Col col(index id) noexcept         { return Col(*this, id); }
-	constexpr const_Col   col(index id) const noexcept
+	[[nodiscard]] constexpr const_Col   col(index id) const noexcept
 									   { return const_Col(*this, id); }
 	Col col(Location loc) noexcept     { return Col(*this, loc); }
-	constexpr const_Col   col(Location loc) const noexcept
+	[[nodiscard]] constexpr const_Col   col(Location loc) const noexcept
 									   { return const_Col(*this, loc); }
 	Block block(index id) noexcept     { return Block(*this, id); }
-	constexpr const_Block block(index id) const noexcept
+	[[nodiscard]] constexpr const_Block block(index id) const noexcept
 									   { return const_Block(*this, id); }
 	Block block(Location loc) noexcept { return Block(*this, loc); }
-	constexpr const_Block block(Location loc) const noexcept
+	[[nodiscard]] constexpr const_Block block(Location loc) const noexcept
 									   { return const_Block(*this, loc); }
 	// clang-format on
 

--- a/Sudoku/Sudoku/Board_Section.h
+++ b/Sudoku/Sudoku/Board_Section.h
@@ -98,16 +98,22 @@ public:
 
 	constexpr iterator begin() noexcept { return iterator(&board_, id_, 0); }
 	constexpr iterator end() noexcept { return iterator(&board_, id_, size()); }
-	constexpr const_iterator cbegin() const noexcept
+	[[nodiscard]] constexpr const_iterator cbegin() const noexcept
 	{
 		return const_iterator(&board_, id_, 0);
 	}
-	constexpr const_iterator cend() const noexcept
+	[[nodiscard]] constexpr const_iterator cend() const noexcept
 	{
 		return const_iterator(&board_, id_, size());
 	}
-	constexpr const_iterator begin() const noexcept { return cbegin(); }
-	constexpr const_iterator end() const noexcept { return cend(); }
+	[[nodiscard]] constexpr const_iterator begin() const noexcept
+	{
+		return cbegin();
+	}
+	[[nodiscard]] constexpr const_iterator end() const noexcept
+	{
+		return cend();
+	}
 	constexpr reverse_iterator rbegin() noexcept
 	{
 		return reverse_iterator(&board_, id_, size() - 1);
@@ -116,19 +122,22 @@ public:
 	{
 		return reverse_iterator(&board_, id_, -1);
 	}
-	constexpr const_reverse_iterator crbegin() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept
 	{
 		return const_reverse_iterator(&board_, id_, size() - 1);
 	}
-	constexpr const_reverse_iterator crend() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator crend() const noexcept
 	{
 		return const_reverse_iterator(&board_, id_, -1);
 	}
-	constexpr const_reverse_iterator rbegin() const noexcept
+	[[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept
 	{
 		return crbegin();
 	}
-	constexpr const_reverse_iterator rend() const noexcept { return crend(); }
+	[[nodiscard]] constexpr const_reverse_iterator rend() const noexcept
+	{
+		return crend();
+	}
 
 private:
 	OwnerT board_;

--- a/Sudoku/Sudoku/Location.h
+++ b/Sudoku/Sudoku/Location.h
@@ -14,8 +14,8 @@
 #pragma once
 
 #include "Size.h"
-#include <gsl/gsl> // index
-#include <type_traits>  // is_signed
+#include <gsl/gsl>     // index
+#include <type_traits> // is_signed
 
 
 namespace Sudoku
@@ -44,22 +44,31 @@ public:
 	}
 
 	// information
-	constexpr index element() const noexcept { return id_; } // default [0,full)
-	constexpr index row() const noexcept { return id_ / Size::elem; } //[0,elem)
-	constexpr index col() const noexcept { return id_ % Size::elem; } //[0,elem)
-	constexpr index block() const noexcept
+	[[nodiscard]] constexpr index element() const noexcept
+	{
+		return id_; // default [0,full)
+	}
+	[[nodiscard]] constexpr index row() const noexcept
+	{
+		return id_ / Size::elem; //[0,elem)
+	}
+	[[nodiscard]] constexpr index col() const noexcept
+	{
+		return id_ % Size::elem; //[0,elem)
+	}
+	[[nodiscard]] constexpr index block() const noexcept
 	{
 		return row() / Size::base * Size::base + col() / Size::base; // [0,elem)
 	}
-	constexpr index block_row() const noexcept
+	[[nodiscard]] constexpr index block_row() const noexcept
 	{
 		return row() % Size::base; // [0,base)
 	}
-	constexpr index block_col() const noexcept
+	[[nodiscard]] constexpr index block_col() const noexcept
 	{
 		return col() % Size::base; // [0,base)
 	}
-	constexpr index block_elem() const noexcept
+	[[nodiscard]] constexpr index block_elem() const noexcept
 	{
 		return block_row() * Size::base + block_col(); // [0,elem)
 	}
@@ -121,22 +130,22 @@ public:
 	{ // empty constructor
 	}
 
-	constexpr gsl::index id() const noexcept
+	[[nodiscard]] constexpr gsl::index id() const noexcept
 	{
-		return loc_.block();
-	} // [0,elem)
-	constexpr gsl::index element() const noexcept
+		return loc_.block(); // [0,elem)
+	}
+	[[nodiscard]] constexpr gsl::index element() const noexcept
 	{
 		return loc_.block_elem(); // [0,elem)
 	}
-	constexpr gsl::index row() const noexcept
+	[[nodiscard]] constexpr gsl::index row() const noexcept
 	{
-		return loc_.block_row();
-	} // [0,base)
-	constexpr gsl::index col() const noexcept
+		return loc_.block_row(); // [0,base)
+	}
+	[[nodiscard]] constexpr gsl::index col() const noexcept
 	{
-		return loc_.block_col();
-	} // [0,base)
+		return loc_.block_col(); // [0,base)
+	}
 
 	// [[implicit]]
 	constexpr operator Location() const noexcept { return loc_; }

--- a/Sudoku/Sudoku/exceptions.h
+++ b/Sudoku/Sudoku/exceptions.h
@@ -29,7 +29,7 @@ struct invalid_Location : public std::out_of_range
 	{
 	}
 
-	virtual const char* where() const noexcept { return where_; }
+	[[nodiscard]] virtual const char* where() const noexcept { return where_; }
 
 private:
 	const char* where_{std::nullptr_t{}};

--- a/SudokuTests/.clang-tidy
+++ b/SudokuTests/.clang-tidy
@@ -7,7 +7,8 @@
 ##====--------------------------------------------------------------------====##
 #
 
-HeaderFilterRegex: 'Sudoku[\\\/].*'
+HeaderFilterRegex: Sudoku(Tests)?[\\\/].*
+FormatStyle: file
 Checks:
  '*,
   abseil-*,

--- a/SudokuTests/.clang-tidy
+++ b/SudokuTests/.clang-tidy
@@ -36,6 +36,7 @@ Checks:
   -llvm-namespace-comment,
   misc-*,
   modernize-*,
+  -modernize-use-trailing-return-type,
   -mpi-*,
   -objc-*,
   performance-*,

--- a/SudokuTests/.clang-tidy
+++ b/SudokuTests/.clang-tidy
@@ -7,10 +7,10 @@
 ##====--------------------------------------------------------------------====##
 #
 
+---
 HeaderFilterRegex: Sudoku(Tests)?[\\\/].*
 FormatStyle: file
-Checks:
- '*,
+Checks: '*,
   abseil-*,
   -android-*,
   boost-*,
@@ -66,23 +66,25 @@ Checks:
   -modernize-use-equals-delete'
 
 CheckOptions:
-  - key:   bugprone-argument-comment.StrictMode
-    value: '1'
-  - key:   bugprone-assert-side-effect.CheckFunctionCalls
-    value: '0'
-  - key:   bugprone-suspicious-enum-usage.StrictMode
-    value: '1'
-  - key:   portability-simd-intrinsics.Suggest
-    value: '1'
-  - key:   readability-braces-around-statements.ShortStatementLines
-    value: '3'
-  - key:   readability-function-size.BranchThreshold
-    value: '-1'
-  - key:   readability-function-size.LineThreshold
-    value: '-1'
-  - key:   readability-function-size.NestingThreshold
-    value: '-1'
-  - key:   readability-function-size.ParameterThreshold
-    value: '-1'
-  - key:   readability-function-size.StatementThreshold
-    value: '800'
+- key:   bugprone-argument-comment.StrictMode
+  value: '1'
+- key:   bugprone-assert-side-effect.CheckFunctionCalls
+  value: '0'
+- key:   bugprone-suspicious-enum-usage.StrictMode
+  value: '1'
+- key:   portability-simd-intrinsics.Suggest
+  value: '1'
+- key:   readability-braces-around-statements.ShortStatementLines
+  value: '3'
+- key:   readability-function-size.BranchThreshold
+  value: '-1'
+- key:   readability-function-size.LineThreshold
+  value: '-1'
+- key:   readability-function-size.NestingThreshold
+  value: '-1'
+- key:   readability-function-size.ParameterThreshold
+  value: '-1'
+- key:   readability-function-size.StatementThreshold
+  value: '800'
+
+...

--- a/SudokuTests/Board.cpp
+++ b/SudokuTests/Board.cpp
@@ -453,12 +453,13 @@ TEST(Board, access_checked)
 	static_assert(not noexcept(cB.at(Location<2>(20)) == 1));
 	static_assert(not noexcept(cexprB.at(Location<2>(20)) == 1));
 	static_assert(std::is_same_v<int const&, decltype(cB.at(Location<2>(2)))>);
+	[[maybe_unused]] int tmp;
 	EXPECT_EQ(cB.at(Location<2>(2)), 2) << "at(Location) const";
-	EXPECT_THROW(cB.at(Location<2>(16)), invalid_Location);
-	EXPECT_THROW(cB.at(Location<2>(-1)), invalid_Location);
-	EXPECT_THROW(cB.at(Location<2>(16)), std::out_of_range);
-	EXPECT_THROW(cB.at(Location<2>(-1)), std::out_of_range);
-	EXPECT_THROW(cB.at(Location<2>{4, 0}), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(Location<2>(16)), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(Location<2>(-1)), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(Location<2>(16)), std::out_of_range);
+	EXPECT_THROW(tmp = cB.at(Location<2>(-1)), std::out_of_range);
+	EXPECT_THROW(tmp = cB.at(Location<2>{4, 0}), invalid_Location);
 
 	// at(row, col)
 	// at(row, col)
@@ -486,7 +487,7 @@ TEST(Board, access_checked)
 	EXPECT_THROW(B1.at(-1, 0), invalid_Location);
 	EXPECT_THROW(B1.at(1, -2), invalid_Location);
 	// at(Location) const
-	EXPECT_NO_THROW(cB.at(2, 1));
+	EXPECT_NO_THROW(tmp = cB.at(2, 1));
 #if not defined(__clang__) && (defined(_MSC_VER) && _MSC_VER < 1922 ||         \
 							   defined(__GNUC__) && __GNUC__ < 9)
 	static_assert(noexcept(cB.at(0, 1) == 1));
@@ -494,10 +495,10 @@ TEST(Board, access_checked)
 	static_assert(not noexcept(cB.at(0, 1) == 1));
 #endif
 	static_assert(not noexcept(cB.at(0, 9) == 1));
-	EXPECT_THROW(cB.at(1, 4), invalid_Location);
-	EXPECT_THROW(cB.at(4, 0), invalid_Location);
-	EXPECT_THROW(cB.at(-1, 0), invalid_Location);
-	EXPECT_THROW(cB.at(1, -2), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(1, 4), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(4, 0), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(-1, 0), invalid_Location);
+	EXPECT_THROW(tmp = cB.at(1, -2), invalid_Location);
 	static_assert(std::is_same_v<int const&, decltype(cB.at(2, 2))>);
 	EXPECT_EQ(cB.at(0, 0), 0);
 	EXPECT_EQ(cB.at(3, 1), 13);


### PR DESCRIPTION
- Run a clang-tidy job on TravisCI.
  For now this job is allowed to fail. Fixes and suppression decisions can follow.
- Move CMake and clang-tidy into a new stage `Validation` executed after `Build & Test Latest` but before the bulk in `Build & Test`.
  When a job in `Validation` fails there is no need to run all the older builds.