### PR TITLE
CMake v3.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ jobs:
   - name: Unity-Build
     stage: "Validation"
     env:
-    - CMake_version: 3.16.0-rc3 # CMAKE_UNITY_BUILD requires at least v3.16.0
+    - CMake_version: 3.16.0-rc4 # CMAKE_UNITY_BUILD requires at least v3.16.0
     - UNITY_BUILD: on
     workspaces:
       use: Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
   - name: CMake versions
     stage: "Validation"
     env:
-    - CMake_version: '"3.15.5 3.14.7 3.13.5 3.12.4 3.12.0"'
+    - CMake_version: '"3.16.0 3.15.5 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
       use: Linux
     addons:
@@ -96,7 +96,7 @@ jobs:
     os: osx
     osx_image: xcode10.3 # AppleClang 10.0.1
     env:
-    - CMake_version: '"3.15.5 3.14.7 3.13.5 3.12.4 3.12.0"'
+    - CMake_version: '"3.16.0 3.15.5 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
       use: OSX
     script:
@@ -128,7 +128,7 @@ jobs:
   - name: Unity-Build
     stage: "Validation"
     env:
-    - CMake_version: 3.16.0-rc4 # CMAKE_UNITY_BUILD requires at least v3.16.0
+    - CMake_version: 3.16.0 # CMAKE_UNITY_BUILD requires at least v3.16.0
     - UNITY_BUILD: on
     workspaces:
       use: Linux
@@ -138,7 +138,7 @@ jobs:
     env:
     - CC:  gcc-9
     - CXX: g++-9
-    - CMake_version: 3.15.5
+    - CMake_version: 3.16.0
     - Coverage: gcov-9
     workspaces:
       use: Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ jobs:
   - name: Unity-Build
     stage: "Validation"
     env:
-    - CMake_version: 3.16.0-rc1 # CMAKE_UNITY_BUILD requires at least v3.16.0
+    - CMake_version: 3.16.0-rc3 # CMAKE_UNITY_BUILD requires at least v3.16.0
     - UNITY_BUILD: on
     workspaces:
       use: Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,14 @@ jobs:
         - clang-9
         - clang-tidy-9
 
+  - name: Unity-Build
+    stage: "Validation"
+    env:
+    - CMake_version: 3.16.0-rc1 # CMAKE_UNITY_BUILD requires at least v3.16.0
+    - UNITY_BUILD: on
+    workspaces:
+      use: Linux
+
   - name: GCC-9
     stage: "Build & Test Latest"
     env:
@@ -663,6 +671,7 @@ before_script:
   if [[ ${CMAKE_CXX_CLANG_TIDY:-} ]]; then
     SharedGenFlags+=("-DCMAKE_CXX_CLANG_TIDY=${CMAKE_CXX_CLANG_TIDY}")
   fi
+  if [[ ${UNITY_BUILD:-} ]]; then SharedGenFlags+=("-DCMAKE_UNITY_BUILD=ON"); fi
   SharedGenFlags+=(-Wdev -Werror=dev --warn-uninitialized)
   CMakeGenFlags1+=(${SharedGenFlags[@]})
   echo ${CMakeGenFlags1[@]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -411,6 +411,21 @@ jobs:
 ## Install tools and dependencies
 before_install:
 - |
+  # Helper functions
+  # usage: if [[ $(check_url '<url>') ]]; then ...
+  function check_url {( set +e
+    if [[ "$1" =~ 'github.com' ]]; then # check for first byte
+      if curl --fail --silent --output /dev/null --connect-timeout 12 \
+        --range 0-0 "$1"
+      then echo true; fi
+    else # request head
+      if curl --fail --silent --output /dev/null --connect-timeout 12 \
+        --head "$1"
+      then echo true; fi
+    fi
+    return
+  )}
+- |
   # Setup
   mkdir -p ~/tools && cd ~/tools
   if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
@@ -563,18 +578,21 @@ install:
     fi
     for VERSION in ${CMake_version:-}; do
       CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${VERSION}/cmake-${VERSION}-${OS}-x86_64.${EXT}"
-      curl -sSL ${CMAKE_URL} -o ${CMAKE_INSTALLER}
-      CMAKE_DIR="${CMAKE_DEFAULT_DIR:-"${HOME}/tools/cmake-${VERSION}"}"
-      mkdir -p ${CMAKE_DIR}
-      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-        chmod +x ${CMAKE_INSTALLER}
-        sudo ./${CMAKE_INSTALLER} --prefix=${CMAKE_DIR} --skip-license
-      else # OSX
-        mkdir -p ./CMake_tmp
-        tar --extract --gzip --file=${CMAKE_INSTALLER} --directory=./CMake_tmp
-        mv ./CMake_tmp/*/CMake.app/Contents/* ${CMAKE_DIR}
+      if [[ $(check_url "$CMAKE_URL") ]]; then
+        curl -sSL ${CMAKE_URL} -o ${CMAKE_INSTALLER}
+        CMAKE_DIR="${CMAKE_DEFAULT_DIR:-"${HOME}/tools/cmake-${VERSION}"}"
+        mkdir -p ${CMAKE_DIR}
+        if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+          chmod +x ${CMAKE_INSTALLER}
+          sudo ./${CMAKE_INSTALLER} --prefix=${CMAKE_DIR} --skip-license
+        else # OSX
+          mkdir -p ./CMake_tmp
+          tar --extract --gzip --file=${CMAKE_INSTALLER} --directory=./CMake_tmp
+          mv ./CMake_tmp/*/CMake.app/Contents/* ${CMAKE_DIR}
+        fi
+        rm --recursive --force ./CMake_tmp ${CMAKE_INSTALLER}
+      else echo 'Invalid url!'; echo "Version: ${VERSION}"
       fi
-      rm --recursive --force ./CMake_tmp ${CMAKE_INSTALLER}
     done
   )
   if [[ "${TRAVIS_OS_NAME}" == "osx" && ! ("${CMake_version:-}" =~ .+[' '].+) ]]

--- a/.travis.yml
+++ b/.travis.yml
@@ -321,6 +321,7 @@ jobs:
       use: OSX
 
   - name: AppleClang Xcode-11.1
+    if: branch =~ /^(master|[Tt]ravis.*)$/
     stage: "Build & Test"
     os: osx
     osx_image: xcode11.1 # AppleClang 11.0.0 same compiler and linker as Xcode11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ## Base configuration.
 ##
 ##====--------------------------------------------------------------------====##
-cmake_minimum_required(VERSION 3.12...3.15)
+cmake_minimum_required(VERSION 3.12...3.16)
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
 project(fwk_Sudoku LANGUAGES CXX)

--- a/Console/CMakeLists.txt
+++ b/Console/CMakeLists.txt
@@ -179,5 +179,9 @@ endif()
 
 ##====--------------------------------------------------------------------====##
 # Custom settings for precompiled headers
-set_precompiled_header(console "precompiled.h" "precompiled.cpp")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+  target_precompile_headers(console PRIVATE precompiled.h)
+elseif(NOT DISABLE_PRECOMPILE_HEADERS)
+  set_precompiled_header(console "precompiled.h" "precompiled.cpp")
+endif()
 

--- a/SudokuTests/Board_Iterators.cpp
+++ b/SudokuTests/Board_Iterators.cpp
@@ -2792,4 +2792,4 @@ TEST(BoardIterator, IteratorLoop)
 	EXPECT_EQ(total, 129);
 }
 
-} // namespace SudokuTests::BoardTest
+} // namespace SudokuTests::BoardIterator

--- a/SudokuTests/Board_Iterators.cpp
+++ b/SudokuTests/Board_Iterators.cpp
@@ -39,7 +39,7 @@
 #include <type_traits>
 
 
-namespace SudokuTests::BoardTest
+namespace SudokuTests::BoardIterator
 {
 using ::Sudoku::Board;
 using ::Sudoku::Location;

--- a/SudokuTests/Board_Section.cpp
+++ b/SudokuTests/Board_Section.cpp
@@ -474,7 +474,7 @@ namespace assignment
 	static_assert(not std::is_assignable_v<Col, Block>);
 	// ...
 } // namespace assignment
-} // namespace SudokuTests::Type
+} // namespace SudokuTests::Section::Type
 
 namespace SudokuTests::Section::Members
 {
@@ -732,7 +732,7 @@ TEST(BoardSection, checkedAccess)
 	EXPECT_THROW(tmp = row.at(-1), std::out_of_range);
 }
 
-} // namespace SudokuTests::Members
+} // namespace SudokuTests::Section::Members
 
 namespace SudokuTests::Section::Iterators
 {
@@ -755,4 +755,4 @@ static_assert(noexcept(const_Row(std::declval<Board&>(), 0).cbegin()));
 static_assert(noexcept(const_Row(std::declval<Board&>(), 0).rbegin()));
 static_assert(noexcept(const_Row(std::declval<Board&>(), 0).crbegin()));
 static_assert(noexcept(Row(std::declval<Board&>(), 0).end()));
-} // namespace SudokuTests::Iterators
+} // namespace SudokuTests::Section::Iterators

--- a/SudokuTests/Board_Section.cpp
+++ b/SudokuTests/Board_Section.cpp
@@ -26,7 +26,7 @@
 #include <cstdint>
 
 
-namespace SudokuTests::Type
+namespace SudokuTests::Section::Type
 {
 namespace properties_Section
 {
@@ -476,7 +476,7 @@ namespace assignment
 } // namespace assignment
 } // namespace SudokuTests::Type
 
-namespace SudokuTests::Members
+namespace SudokuTests::Section::Members
 {
 using ::Sudoku::Board;
 using ::Sudoku::Board_Section::Row;
@@ -734,7 +734,7 @@ TEST(BoardSection, checkedAccess)
 
 } // namespace SudokuTests::Members
 
-namespace SudokuTests::Iterators
+namespace SudokuTests::Section::Iterators
 {
 using Board       = ::Sudoku::Board<int, 3>;
 using Row         = ::Sudoku::Board_Section::Row<int, 3>;

--- a/SudokuTests/Board_Section_iterator.cpp
+++ b/SudokuTests/Board_Section_iterator.cpp
@@ -55,7 +55,7 @@ using ::Sudoku::Board_Section::reverse_Block_iterator;
 using ::Sudoku::Board_Section::const_reverse_Row_iterator;
 using ::Sudoku::Board_Section::const_reverse_Col_iterator;
 using ::Sudoku::Board_Section::const_reverse_Block_iterator;
-} // namespace SudokuTests
+} // namespace SudokuTests::Section_Iterator
 
 namespace SudokuTests::Section_Iterator::Type
 {
@@ -299,7 +299,7 @@ namespace assignment
 	static_assert(not std::is_assignable_v<L, typeT>);
 } // namespace assignment
 
-} // namespace SudokuTests::Type
+} // namespace SudokuTests::Section_Iterator::Type
 
 namespace SudokuTests::Section_Iterator::Members
 {
@@ -2238,4 +2238,4 @@ TEST(SectionItr, IteratorLoop)
 	}
 	EXPECT_EQ(total, 129);
 }
-} // namespace SudokuTests::Members
+} // namespace SudokuTests::Section_Iterator::Members

--- a/SudokuTests/Board_Section_iterator.cpp
+++ b/SudokuTests/Board_Section_iterator.cpp
@@ -30,7 +30,7 @@
 #include <type_traits>
 #include <cstdint>
 
-namespace SudokuTests
+namespace SudokuTests::Section_Iterator
 {
 using ::Sudoku::Board;
 using ::Sudoku::Location;
@@ -57,7 +57,7 @@ using ::Sudoku::Board_Section::const_reverse_Col_iterator;
 using ::Sudoku::Board_Section::const_reverse_Block_iterator;
 } // namespace SudokuTests
 
-namespace SudokuTests::Type
+namespace SudokuTests::Section_Iterator::Type
 {
 using dataT             = int;
 constexpr int size      = 3;
@@ -301,7 +301,7 @@ namespace assignment
 
 } // namespace SudokuTests::Type
 
-namespace SudokuTests::Members
+namespace SudokuTests::Section_Iterator::Members
 {
 using ::Sudoku::traits::is_input;
 using ::Sudoku::traits::is_forward;

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -306,7 +306,11 @@ endif(CODE_COVERAGE)
 
 ##====--------------------------------------------------------------------====##
 # custom settings for precompiled headers
-set_precompiled_header(SudokuTests "precompiled.h" "precompiled.cpp")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+  target_precompile_headers(SudokuTests PRIVATE precompiled.h)
+elseif(NOT DISABLE_PRECOMPILE_HEADERS)
+  set_precompiled_header(SudokuTests "precompiled.h" "precompiled.cpp")
+endif()
 
 ##====--------------------------------------------------------------------====##
 gtest_discover_tests(SudokuTests)

--- a/SudokuTests/Solvers_find.cpp
+++ b/SudokuTests/Solvers_find.cpp
@@ -37,7 +37,7 @@
 #include <type_traits>
 
 
-namespace SudokuTests::SolversTest
+namespace SudokuTests::Solvers_find
 {
 using ::Sudoku::Board;
 using ::Sudoku::Location;

--- a/SudokuTests/Solvers_find.cpp
+++ b/SudokuTests/Solvers_find.cpp
@@ -1048,4 +1048,4 @@ TEST(Solver, appearanceSets)
 	}
 }
 
-} // namespace SudokuTests::SolversTest
+} // namespace SudokuTests::Solvers_find

--- a/SudokuTests/Solvers_remove_option.cpp
+++ b/SudokuTests/Solvers_remove_option.cpp
@@ -514,4 +514,4 @@ TEST(Solver, deathtestsRemoveOption)
 		"Assertion .*intersect_block.*");
 }
 
-} // namespace SudokuTests::SolversTest
+} // namespace SudokuTests::Solvers_remove_option

--- a/SudokuTests/Solvers_remove_option.cpp
+++ b/SudokuTests/Solvers_remove_option.cpp
@@ -35,7 +35,7 @@
 #include <type_traits>
 
 
-namespace SudokuTests::SolversTest
+namespace SudokuTests::Solvers_remove_option
 {
 using ::Sudoku::Board;
 using ::Sudoku::Location;

--- a/SudokuTests/Solvers_set_option.cpp
+++ b/SudokuTests/Solvers_set_option.cpp
@@ -667,4 +667,4 @@ TEST(Solver, deathtestSetOption)
 	//}
 }
 
-} // namespace SudokuTests::SolversTest
+} // namespace SudokuTests::Solvers_set_option

--- a/SudokuTests/Solvers_set_option.cpp
+++ b/SudokuTests/Solvers_set_option.cpp
@@ -33,7 +33,7 @@
 #include <type_traits>
 
 
-namespace SudokuTests::SolversTest
+namespace SudokuTests::Solvers_set_option
 {
 using ::Sudoku::Board;
 using ::Sudoku::Location;

--- a/cmake/add_to_source_file_properties.cmake
+++ b/cmake/add_to_source_file_properties.cmake
@@ -55,7 +55,7 @@ include_guard()
 
 
 function(set_source_files_compile_definitions)
-  cmake_minimum_required(VERSION 3.12...3.15) # list(SUBLIST ...
+  cmake_minimum_required(VERSION 3.12...3.16) # list(SUBLIST ...
   list(FIND ARGN DEFINITIONS prop_loc)
   if(${prop_loc} EQUAL -1)
     message(SEND_ERROR "Missing keyword DEFINITIONS.")


### PR DESCRIPTION
- Add 3.16 to supported version set
- Use build-in support for precompiled headers
- Support build-in unity-build support
  - Add Unity-Build job on TravisCI: detect ODR-violations
- Add to test set on TravisCI