### PR TITLE
Local GitHub action for cpplint

### DIFF
--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -1,8 +1,10 @@
 ##====---- .github/workflow/cpplint.yml                               ----====##
+# Based on github.com/cpplint/GitHub-Action-for-cpplint
+#
 name: cpplint
-on: push
+on: [push, pull_request]
 jobs:
-  gitHubActionForCpplint:
+  cpplint:
     name: Run cpplint
     runs-on: ubuntu-latest
     steps:
@@ -10,7 +12,6 @@ jobs:
       uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - name: GitHub Action for cpplint
-      uses: cpplint/GitHub-Action-for-cpplint@master
-      with:
-        args: cpplint --verbose=0 --counting=detailed --recursive .
+    - uses: actions/setup-python@v1
+    - run: pip install cpplint
+    - run: cpplint --verbose=0 --counting=detailed --recursive .

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
   - name: CMake versions
     stage: "Validation"
     env:
-    - CMake_version: '"3.16.0 3.15.5 3.14.7 3.13.5 3.12.4 3.12.0"'
+    - CMake_version: '"3.16.1 3.15.6 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
       use: Linux
     addons:
@@ -96,7 +96,7 @@ jobs:
     os: osx
     osx_image: xcode10.3 # AppleClang 10.0.1
     env:
-    - CMake_version: '"3.16.0 3.15.5 3.14.7 3.13.5 3.12.4 3.12.0"'
+    - CMake_version: '"3.16.1 3.15.6 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
       use: OSX
     script:
@@ -128,7 +128,7 @@ jobs:
   - name: Unity-Build
     stage: "Validation"
     env:
-    - CMake_version: 3.16.0 # CMAKE_UNITY_BUILD requires at least v3.16.0
+    - CMake_version: 3.16.1 # CMAKE_UNITY_BUILD requires at least v3.16.0
     - UNITY_BUILD: on
     workspaces:
       use: Linux
@@ -138,7 +138,7 @@ jobs:
     env:
     - CC:  gcc-9
     - CXX: g++-9
-    - CMake_version: 3.16.0
+    - CMake_version: 3.16.1
     - Coverage: gcov-9
     workspaces:
       use: Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 ##====--------------------------------------------------------------------====##
 # (INTERFACE libraries: header-only)
 add_library(Sudoku INTERFACE)
+add_library(fwk::Sudoku ALIAS Sudoku)
 
 target_include_directories(Sudoku
   INTERFACE

--- a/Console/CMakeLists.txt
+++ b/Console/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(console
 
 target_link_libraries(console
   PRIVATE
-    Sudoku
+    fwk::Sudoku
 )
 
 set_target_properties(console

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -43,7 +43,7 @@ target_sources(SudokuTests
 
 target_link_libraries(SudokuTests
   PRIVATE
-    Sudoku
+    fwk::Sudoku
     GTest::GTest
     GTest::Main
 )


### PR DESCRIPTION
Removing the dependency on [cpplint/GitHub-Action-for-cpplint](https://github.com/cpplint/GitHub-Action-for-cpplint).
The GitHub action defined there was removed, resulting in test failure.
Implementing the provided sample.

This removes the use of a docker container.

---
CMake changes: defining and using a library target alias fwk:::Sudoku.
These are checked in the `target_link_libraries` function.