### PR TITLE
Fix CMake PCH generation on Windows

### DIFF
--- a/Console/CMakeLists.txt
+++ b/Console/CMakeLists.txt
@@ -124,18 +124,35 @@ if(MSVC) # MSVC or simulating MSVC
       /Qdiag-disable:304,981
     >
   )
-  set_source_files_compile_options(
-    precompiled.cpp
-    OPTIONS
-      $<$<CXX_COMPILER_ID:MSVC>:
-        $<$<CONFIG:Debug>:
-          /wd4365 # stl
+  if(NOT DISABLE_PRECOMPILE_HEADERS)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+      target_compile_options(console PRIVATE
+        $<$<CXX_COMPILER_ID:MSVC>:
+          $<$<CONFIG:Debug>:
+            /wd4365 # stl xmemory
+          >
+          /wd4668 # gsl: multi_span (fixed upstream 2020-04-09)
+          $<$<VERSION_LESS:$<CXX_COMPILER_VERSION>,1920>: # VS2017
+            /wd4774 # stl string
+            /wd5026 # system_error
+          >
         >
-        /wd4668 # gsl_byte
-        /wd4774 # stl
-        /wd5026 # system_error
-      >
-  )
+      )
+    else()
+      set_source_files_compile_options(precompiled.cpp OPTIONS
+        $<$<CXX_COMPILER_ID:MSVC>:
+          $<$<CONFIG:Debug>:
+            /wd4365 # stl
+          >
+          /wd4668 # gsl: multi_span (fixed upstream 2020-04-09)
+          $<$<VERSION_LESS:$<CXX_COMPILER_VERSION>,1920>: # VS2017
+            /wd4774 # stl string
+            /wd5026 # system_error
+          >
+        >
+      )
+    endif()
+  endif()
 else()
   target_compile_options(console PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -166,7 +166,7 @@ if(MSVC) # MSVC or simulating MSVC
     Board.cpp
     Board_Iterators.cpp
     OPTIONS 
-      $<$<CXX_COMPILER_ID:Clang>:-Wno-unevaluated-expression>
+      $<$<CXX_COMPILER_ID:Clang>:-Wno-unevaluated-expression >
   )
   if(DISABLE_PRECOMPILE_HEADERS OR CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
     target_compile_options(SudokuTests PRIVATE

--- a/SudokuTests/CMakeLists.txt
+++ b/SudokuTests/CMakeLists.txt
@@ -139,9 +139,7 @@ if(MSVC) # MSVC or simulating MSVC
     $<$<CXX_COMPILER_ID:MSVC>:
       /W4
       ${MSVC_Extra_Warnings}
-      /wd4365 # stl
       /wd4623 # gtest
-      /wd4668 # gsl_byte & gtest
       /wd4774 # stl
       /wd5026 # system_error & gtest
     >
@@ -170,12 +168,22 @@ if(MSVC) # MSVC or simulating MSVC
     OPTIONS 
       $<$<CXX_COMPILER_ID:Clang>:-Wno-unevaluated-expression>
   )
-  set_source_files_compile_options(
-    precompiled.cpp
-    OPTIONS
+  if(DISABLE_PRECOMPILE_HEADERS OR CMAKE_VERSION VERSION_GREATER_EQUAL 3.16)
+    target_compile_options(SudokuTests PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:
-        /wd4251 # gtest (needs to have dll-interface to be used by clients)
-        /wd4275 # gtest (non dll-interface class used as base for dll-interface)
+        $<$<CONFIG:Debug>:
+          /wd4365 # stl xmemory
+        >
+        /wd4668 # gtest undefined macros
+      >
+    )
+  else()
+    set_source_files_compile_options(precompiled.cpp OPTIONS
+      $<$<CXX_COMPILER_ID:MSVC>:
+        $<$<CONFIG:Debug>:
+          /wd4365 # stl
+        >
+        /wd4668 # gtest undefined macros
       >
       $<$<CXX_COMPILER_ID:Clang>:
         -Wno-deprecated # gtest
@@ -185,7 +193,8 @@ if(MSVC) # MSVC or simulating MSVC
         -Wno-undef
         -Wno-unused-parameter # gtest
       >
-  )
+    )
+  endif()
 else()
   target_compile_options(SudokuTests PRIVATE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:

--- a/SudokuTests/README.md
+++ b/SudokuTests/README.md
@@ -31,11 +31,16 @@ The preprocessor macro `fwkUnitTest` needs to be defined to disable the
 <!------------------------------------------------------------><a id="msvc"></a>
 ### VC++
 <!----------------------------------------------------------------------------->
+Disabled warnings:
+````
+/wd4623
+/wd4774
+/wd5026
+````
 #### Custom settings for precompiled.cpp
 ```
-/wd4619   pragma warning: there is no warning number 'number'
-          gTest, warning 4800 was removed in VS2007
-          not working ... preprocessor macros...
+/wd4365   Debug only, stl xmemory
+/wd4668   gtest undefined macros
 ```
 
 <!-----------------------------------------------------------><a id="clang"></a>
@@ -50,6 +55,7 @@ Disabled warnings:
 -Wno-c++98-compat-pedantic
 -Wno-covered-switch-default  gTest macro debug-death on: Board.cpp
 -Wno-global-constructors     gTest macro
+-Wno-padded
 -Wno-used-but-marked-unused  gTest macros
 -Wno-zero-as-null-pointer-constant  Board_Section_iterator.cpp
 ``````

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -358,8 +358,6 @@ Linker:    Generate debug info:      no
 /guard:cf  Control flow guard (v7.0.0+)
 /Oi        Enable intrinsic functions.
 /MT        Use static run-time
-/guard:cf  Control flow guard (v7.0.0+)
-/Oi        Enable intrinsic functions.
 ```
 
 #### Enable Warnings
@@ -370,16 +368,6 @@ setting is disabled.
 [Clang diagnostics reference](https://clang.llvm.org/docs/DiagnosticsReference.html)
 ````
 /Wall                Enables -Weverything
-  -Weverything       All warnings enabled
-  -Wall              
-  -Wextra            
-  -Wpedantic         ISO C/C++ conformance (warn on extensions)
-  -Wconversion       Enable warnings for unexpected conversions losing data on
-                     fundamental types, enums and strings.
-  -Wshadow-all       Uncaptured locals; Variable declaration overshadows one
-                     from the parent context. (Same name.)
-  -Wold-style-cast   Warn for c-style casts
-  -Wdouble-promotion `float` implicit promoted to `double`
 ````
 ##### Promote to errors
 ````````
@@ -394,6 +382,14 @@ setting is disabled.
   In LLVM/Clang pre v7.0.0 and AppleClang pre v10.0.1
 -Wno-missing-braces
   In LLVM/Clang release v5.0.(0|1)  False positive
+-Wno-weak-vtables (linux/osx)
+
+SudokuTests
+  -Wno-covered-switch-default
+  -Wno-global-constructors
+  -Wno-padded (linux)
+  -Wno-used-but-marked-unused
+  -Wno-zero-as-null-pointer-constant (win only)
 ``````
 
 <!-----------------------------------------------------------><a id="intel"></a>


### PR DESCRIPTION
With CMake release 3.16 comes integrated support for precompiled headers.
This does not allow for disabling of warnings specific to the pch file during pch generation.

No space between the last command (`-Wno-unevaluated-expression`)  before the pch `/YuC:`