### PR TITLE
TravisCI: Fix building of vcpkg and usage in Linux workspaces 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -434,7 +434,7 @@ jobs:
       create:
         name: Linux
         paths:
-        - ~/tools/.cache/vcpkg
+        - ${VCPKG_DIR}
     install: skip
     before_script: skip
     script: skip
@@ -447,7 +447,7 @@ jobs:
       create:
         name: OSX
         paths:
-        - ~/tools/.cache/vcpkg
+        - ${VCPKG_DIR}
     os: osx
     osx_image: xcode10.3
     env:
@@ -509,11 +509,12 @@ before_install:
   fi
 - |
   # Download vcpkg
+  if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
   ( set -euo pipefail
     # Full history clone for rebuild detection.
     git clone --quiet https://github.com/Microsoft/vcpkg.git ${VCPKG_DIR}
     mv -f -t ${VCPKG_DIR} ~/tools/.cache/vcpkg/* || echo "No cached files."
-  )
+  ); fi
   export PATH=$PATH:${VCPKG_DIR}
 - |
   # Install/Update vcpkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ git:
 env:
   global:
   # vcpkg
-  - VCPKG_DIR:       $HOME/tools/vcpkg
+  - VCPKG_DIR:      "$HOME/tools/vcpkg"
   - TOOLCHAIN_FILE: "$HOME/tools/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
 ##====--------------------------------------------------------------------====##
@@ -519,7 +519,7 @@ before_install:
 - |
   # Install/Update vcpkg
   if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
-    cd ${VCPKG_DIR}
+    pushd ${VCPKG_DIR}
   ( set -euo pipefail
     VCPKG_SRC_HASH="${VCPKG_DIR}/vcpkg_src_hash" && touch ${VCPKG_SRC_HASH}
     GENERATE_SRC_HASH="(
@@ -537,10 +537,12 @@ before_install:
       if [[ ${TRAVIS_OS_NAME} == "osx" && ${CXX} == g++-* ]]; then
         export LDFLAGS="${LDFLAGS:-} -static-libstdc++ -static-libgcc"
       fi
-      bootstrap-vcpkg.sh
+      ./bootstrap-vcpkg.sh
       eval ${GENERATE_SRC_HASH} > ${VCPKG_SRC_HASH}
     fi
-  ); fi
+  )
+    popd
+  fi
 - |
   # Using libc++
   if [[ ${CXX} == clang* && ${CXX_lib:-} ]]; then
@@ -682,18 +684,22 @@ install:
       function cmake { command /usr/bin/cmake $@; }
     fi
   fi
-
-- vcpkg install ms-gsl
-- vcpkg install gtest
 - |
-  # Update installed packages
+  # Build/install libraries
+  pushd ${VCPKG_DIR}
+  ./vcpkg install ms-gsl
+  ./vcpkg install gtest
+  popd
+- |
+  # Update installed libraries
+  pushd ${VCPKG_DIR}
   ( set -euo pipefail
-    vcpkg update # print potential updates
-    if [[ $(vcpkg upgrade) != *'installed packages are up-to-date'* ]]
+    ./vcpkg update # print potential updates
+    if [[ $(./vcpkg upgrade) != *'installed packages are up-to-date'* ]]
     then
-      vcpkg upgrade --no-dry-run
+      ./vcpkg upgrade --no-dry-run
     fi
-  )
+  ); popd
 
 ##====--------------------------------------------------------------------====##
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -754,7 +754,7 @@ before_cache:
   # Select files for caching
   mkdir -p ~/tools/.cache/vcpkg
   if [[ "${TRAVIS_BUILD_STAGE_NAME}" =~ .*dependencies$ ]]; then
-    mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/vcpkg_src_hash
+    cp -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/vcpkg ${VCPKG_DIR}/vcpkg_src_hash
   fi
   mv -u -t ~/tools/.cache/vcpkg ${VCPKG_DIR}/installed
 


### PR DESCRIPTION
Recently TravisCI builds fail for Linux when vcpkg was updated.

**Fixes:**
- Moving the `vcpkg` executable for caching resulted in it being excluded from the workspace.
- Execute `vcpkg` in local directory solves new issue where vcpkg errors with: `Error: Could not detect vcpkg-root.`.

**Changes:**
- Add the full vcpkg directory to the workspace. All build-jobs use the same state of the vcpkg repository, as set by the `Build dependencies` stage.