### PR TITLE
Microsoft GSL include using CMake find_package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
   - name: CMake versions
     stage: "Validation"
     env:
-    - CMake_version: '"3.17.1 3.16.6 3.15.7 3.14.7 3.13.5 3.12.4 3.12.0"'
+    - CMake_version: '"3.17.2 3.16.6 3.15.7 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
       use: Linux
     addons:
@@ -99,7 +99,7 @@ jobs:
     os: osx
     osx_image: xcode10.3 # AppleClang 10.0.1
     env:
-    - CMake_version: '"3.17.1 3.16.6 3.15.7 3.14.7 3.13.5 3.12.4 3.12.0"'
+    - CMake_version: '"3.17.2 3.16.6 3.15.7 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
       use: OSX
     script:
@@ -131,7 +131,7 @@ jobs:
   - name: Unity-Build
     stage: "Validation"
     env:
-    - CMake_version: 3.17.1 # CMAKE_UNITY_BUILD requires at least v3.16.0
+    - CMake_version: 3.17.2 # CMAKE_UNITY_BUILD requires at least v3.16.0
     - UNITY_BUILD: on
     workspaces:
       use: Linux
@@ -141,7 +141,7 @@ jobs:
     env:
     - CC:  gcc-9
     - CXX: g++-9
-    - CMake_version: 3.17.1
+    - CMake_version: 3.17.2
     - Coverage: gcov-9
     workspaces:
       use: Linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,16 +36,9 @@ target_compile_features(Sudoku
 
 # Dependencies Sudoku
 ##====--------------------------------------------------------------------====##
-find_path(GSL_INCLUDE_DIR gsl/gsl)
-if(GSL_INCLUDE_DIR)
-  message(STATUS "Found the Guidelines Support Library: ${GSL_INCLUDE_DIR}")
-else()
-  message(FATAL_ERROR "Could not find Guidelines Support Library.")
-endif()
-target_include_directories(Sudoku
-  SYSTEM
-    INTERFACE ${GSL_INCLUDE_DIR}
-)
+find_package(Microsoft.GSL CONFIG REQUIRED)
+message(STATUS "Found the Guidelines Support Library: ${Microsoft.GSL_DIR}")
+target_link_libraries(Sudoku INTERFACE Microsoft.GSL::GSL)
 
 ##====--------------------------------------------------------------------====##
 # Testing Sudoku


### PR DESCRIPTION
Available since Microsoft GSL [release v3.0.0](https://github.com/microsoft/GSL/releases/tag/v3.0.0).
Supported in recent releases of vcpkg.