### PR TITLE
CI: improve linting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@
 coverage:
   precision: 5
   round: down
-  range: "85...100"
+  range: 85...100
 
   status:
     project:
@@ -15,13 +15,13 @@ coverage:
         threshold: 0.5%
       sudoku:
         paths:
-        - "Sudoku/Sudoku/"
+        - Sudoku/Sudoku/
         base: auto
         target: auto
         threshold: 0.5%
       tests:
         paths:
-        - "SudokuTests/"
+        - SudokuTests/
         base: auto
         target: auto
         threshold: 100% # report but never fail
@@ -32,7 +32,7 @@ coverage:
         threshold: 100% # report but never fail
       sudoku:
         paths:
-        - "Sudoku/Sudoku/"
+        - Sudoku/Sudoku/
         target: auto
         only_pulls: true
     changes: false

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -3,7 +3,25 @@
 # LLVM clang-format release 10.0.0 required for `--dry-run`.
 #
 name: clang-format
-on: push
+on:
+  push:
+    paths:
+    - '**.[CcHh]'
+    - '**.[CcHh]\+\+'
+    - '**.[Cc][Cc]'
+    - '**.[CcHh][Pp][Pp]'
+    - '**.[CcHh][Xx][Xx]'
+    - .clang-format
+    - '**/clang-format.yml'
+  pull_request:
+    paths:
+    - '**.[CcHh]'
+    - '**.[CcHh]\+\+'
+    - '**.[Cc][Cc]'
+    - '**.[CcHh][Pp][Pp]'
+    - '**.[CcHh][Xx][Xx]'
+    - .clang-format
+    - '**/clang-format.yml'
 jobs:
   dry-run:
     name: clang-format dry-run

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -13,7 +13,14 @@ on:
     - '**CPPLINT.cfg'
     - '**/cpplint.yml'
   pull_request:
-    branches: '**'
+    paths:
+    - '**.[CcHh]'
+    - '**.[CcHh]\+\+'
+    - '**.[Cc][Cc]'
+    - '**.[CcHh][Pp][Pp]'
+    - '**.[CcHh][Xx][Xx]'
+    - '**CPPLINT.cfg'
+    - '**/cpplint.yml'
 jobs:
   cpplint:
     name: Run cpplint

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -21,6 +21,8 @@ on:
     - '**.[CcHh][Xx][Xx]'
     - '**CPPLINT.cfg'
     - '**/cpplint.yml'
+  schedule: # Verify main branch weakly with latest release
+  - cron: 12 9 * * SAT # Run every Saturday at 09:12 UTC
 jobs:
   cpplint:
     name: Run cpplint

--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -10,6 +10,8 @@ on:
     - '**.[Cc][Cc]'
     - '**.[CcHh][Pp][Pp]'
     - '**.[CcHh][Xx][Xx]'
+    - '**CPPLINT.cfg'
+    - '**/cpplint.yml'
   pull_request:
     branches: '**'
 jobs:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -6,8 +6,8 @@ on:
     paths:
     - '**.yml'
     - '**.yaml'
-    - '.clang-format'
-    - '.clang-tidy'
+    - .clang-format
+    - .clang-tidy
   pull_request:
     branches: '**'
 jobs:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -14,6 +14,8 @@ on:
     - '**.yaml'
     - .clang-format
     - .clang-tidy
+  schedule: # Verify main branch weakly with latest release
+  - cron: 18 9 * * SAT # Run every Saturday at 09:18 UTC
 jobs:
   yamllint:
     name: Run yamllint

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -9,7 +9,11 @@ on:
     - .clang-format
     - .clang-tidy
   pull_request:
-    branches: '**'
+    paths:
+    - '**.yml'
+    - '**.yaml'
+    - .clang-format
+    - .clang-tidy
 jobs:
   yamllint:
     name: Run yamllint

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,16 +63,16 @@ dist: bionic
 
 # Specify Stage Order and Conditions
 stages:
-- "Build Dependencies"
+- Build Dependencies
 - "Build & Test Latest" # First: (4) builds to run first
-- name: "Validation"
+- name: Validation
 - name: "Build & Test"  # If all succeed build rest
-  if: NOT (branch =~ /^([Aa]pp[Vv]eyor|cpplint).*/)
+  if: 'NOT (branch =~ /^([Aa]pp[Vv]eyor|cpplint).*/)'
 
 jobs:
   include:
   - name: CMake versions
-    stage: "Validation"
+    stage: Validation
     env:
     - CMake_version: '"3.17.2 3.16.6 3.15.7 3.14.7 3.13.5 3.12.4 3.12.0"'
     workspaces:
@@ -95,7 +95,7 @@ jobs:
       )
 
   - name: CMake versions
-    stage: "Validation"
+    stage: Validation
     os: osx
     osx_image: xcode10.3 # AppleClang 10.0.1
     env:
@@ -110,7 +110,7 @@ jobs:
       )
 
   - name: Clang-Tidy
-    stage: "Validation"
+    stage: Validation
     env:
     - CC: clang-10
     - CXX: clang++-10
@@ -129,7 +129,7 @@ jobs:
         - clang-tidy-10
 
   - name: Unity-Build
-    stage: "Validation"
+    stage: Validation
     env:
     - CMake_version: 3.17.2 # CMAKE_UNITY_BUILD requires at least v3.16.0
     - UNITY_BUILD: on
@@ -347,7 +347,7 @@ jobs:
         - clang-5.0
 
   - name: Clang-4.0 Debug
-    if: branch =~ /^[Tt]ravis.*$/
+    if: 'branch =~ /^[Tt]ravis.*$/'
     env:
     - CC: clang-4.0
     - CXX: clang++-4.0
@@ -378,7 +378,7 @@ jobs:
       use: OSX
 
   - name: AppleClang Xcode-11.1
-    if: branch =~ /^(master|[Tt]ravis.*)$/
+    if: 'branch =~ /^(master|[Tt]ravis.*)$/'
     stage: "Build & Test"
     os: osx
     osx_image: xcode11.1 # AppleClang 11.0.0 same compiler and linker as Xcode11
@@ -398,7 +398,7 @@ jobs:
       use: OSX
 
   - name: AppleClang Xcode-10.1
-    if: branch =~ /^(master|[Tt]ravis.*)$/
+    if: 'branch =~ /^(master|[Tt]ravis.*)$/'
     os: osx
     osx_image: xcode10.1 # AppleClang 10.0.0 same compiler as Xcode 10.0
     env:
@@ -408,28 +408,28 @@ jobs:
 
   # Note: can not build vcpkg on Xcode-9.3/4, missing OSX update on Travis.
   - name: AppleClang Xcode-9.4
-    if: branch =~ /^(master|[Tt]ravis.*)$/
+    if: 'branch =~ /^(master|[Tt]ravis.*)$/'
     os: osx
     osx_image: xcode9.4 # AppleClang 9.1.0 same compiler as Xcode 9.3
     env:
     - Coverage: grcov
-    - CMake_version: '3.12.4' # Xcode 9.4 comes with CMake 3.11.4
+    - CMake_version: 3.12.4 # Xcode 9.4 comes with CMake 3.11.4
     workspaces:
       use: OSX
 
   # Earliest available with C++17 support
   - name: AppleClang Xcode-9
-    if: branch =~ /^(master|[Tt]ravis.*)$/
+    if: 'branch =~ /^(master|[Tt]ravis.*)$/'
     os: osx
     osx_image: xcode9 # AppleClang 9.1.0 same compiler in Xcode 9.0, 9.1 and 9.2
     env:
     - Coverage: grcov
-    - CMake_version: '3.12.4'
+    - CMake_version: 3.12.4
     workspaces:
       use: OSX
 
   - name: vcpkg for Linux
-    stage: "Build Dependencies"
+    stage: Build Dependencies
     workspaces:
       create:
         name: Linux
@@ -442,7 +442,7 @@ jobs:
     after_success: skip
 
   - name: vcpkg for OSX
-    stage: "Build Dependencies"
+    stage: Build Dependencies
     workspaces:
       create:
         name: OSX

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,8 +3,8 @@
 # Documentation: yamllint.readthedocs.io
 # Run: yamllint .
 #
-# Last updated for: v1.21.0
-# Minimum required: v1.21.0
+# Last updated for: v1.23.0
+# Minimum required: v1.23.0
 ##====--------------------------------------------------------------------====##
 ---
 
@@ -13,8 +13,8 @@ extends: default
 yaml-files: # v1.17.0
 - '*.yaml'
 - '*.yml'
-- '.clang-format'
-- '.clang-tidy'
+- .clang-format
+- .clang-tidy
 
 rules:
   braces:
@@ -70,10 +70,18 @@ rules:
     forbid-implicit-octal: true
   quoted-strings:
     quote-type: any
-    required: false # yamllint v1.21.0
+    required: only-when-needed # v1.21.0
+    extra-allowed: # v1.23.0
+    - '[\/\\]\w|\w[\/\\]' # path
+    - '^\^|\$\/?$|[\|]'   # regex
+    - '.+&.+'    # containing an ampersand (VS rendering)
+    - '\w,[ \w]' # containing a comma (VS rendering)
+    extra-required:
+    - '[\/\\].*\s.*[\/\\].*|[\/\\].*\s.*' # path with white-space
   trailing-spaces: enable
   truthy:
     allowed-values: ['true', 'false', 'on', 'off'] # requires yamllint v1.16.0
+    check-keys: on # v1.22.0
     level: warning
 
 ...

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -8,7 +8,7 @@
 #
 
 set noparent
-exclude_files=[Bb]uild/*
+exclude_files=out|(CPTCMake)[Bb]uild
 
 linelength=80
 

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,4 +1,4 @@
-# cpplint - Goolge C++ style checker
+# cpplint - Google C++ style checker
 #
 # Run: cpplint --verbose=0 --counting=detailed --recursive .
 # All commands: cpplint --help


### PR DESCRIPTION
Minor changes in configuration for cpplint, yamllint and clang-format execution on GitHub Actions.

- weekly run of cpplint an yamllint on main branch (master)
- run al on push and PR, but only when relevant files are changed (including their own configuration)
- cpplint 
- yamllint configuration update to v1.23.0'
  Now capable of checking use of quotes for strings.
  - added some custom regex rules for allowed and required quotes. (imperfect, but working)
  - removal of unnecessary quotes