### PR TITLE
Xcode 11.5 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -471,6 +471,10 @@ jobs:
 
   allow_failures:
   - name: Clang-4.0 Debug
+  # Issues with Ninja 10.0 in vcpkg (not building on MacOS 10.12 & 10.13)
+  - osx_image: xcode9
+  - osx_image: xcode9.4
+  - osx_image: xcode10.1
 
 ##====--------------------------------------------------------------------====##
 ## Install tools and dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -359,8 +359,17 @@ jobs:
         packages:
         - clang-4.0
 
-  - name: AppleClang Xcode-11.4 # based on LLVM 9
+  - name: AppleClang Xcode-11.5 # based on LLVM 10?
     stage: "Build & Test Latest"
+    os: osx
+    osx_image: xcode11.5 # AppleClang ?
+    env:
+    - Coverage: grcov
+    workspaces:
+      use: OSX
+
+  - name: AppleClang Xcode-11.4 # based on LLVM 9
+    stage: "Build & Test"
     os: osx
     osx_image: xcode11.4 # AppleClang 11.0.3
     env:


### PR DESCRIPTION
The new beta release of Xcode 11.5 is available on Travis: [announcement](https://changelog.travis-ci.com/xcode-11-5-build-environment-released-150577).

Ninja-build release 10.0 is not compatible with older versions of MacOS.
A temporary commit allows builds on these platforms to fail.
See issue #45 
