### PR TITLE
MSVC (14.27 / VS2019 16.7) changed some trivially_copyable properties

### DIFF
--- a/SudokuTests/Board_Section.cpp
+++ b/SudokuTests/Board_Section.cpp
@@ -105,7 +105,7 @@ namespace type_properties
 	static_assert(not std::is_const_v<constT>);
 	static_assert(not std::is_volatile_v<typeT>);
 	static_assert(not std::is_trivial_v<typeT>);
-#if defined(_MSC_VER) && _MSC_VER < 1927
+#if defined(_MSC_VER) && _MSC_VER < 1927 && !defined(__clang__)
 	static_assert(not std::is_trivially_copyable_v<typeT>);
 #else
 	static_assert(std::is_trivially_copyable_v<typeT>);

--- a/SudokuTests/Board_Section.cpp
+++ b/SudokuTests/Board_Section.cpp
@@ -105,11 +105,11 @@ namespace type_properties
 	static_assert(not std::is_const_v<constT>);
 	static_assert(not std::is_volatile_v<typeT>);
 	static_assert(not std::is_trivial_v<typeT>);
-#if defined(__clang__) || defined(__GNUC__)
-	static_assert(std::is_trivially_copyable_v<typeT>);
-#else
+#if defined(_MSC_VER) && _MSC_VER < 1927
 	static_assert(not std::is_trivially_copyable_v<typeT>);
-#endif // __clang__
+#else
+	static_assert(std::is_trivially_copyable_v<typeT>);
+#endif // Old MSVC
 	static_assert(not std::is_standard_layout_v<typeT>);
 #if not(defined(__ICL) && __ICL <= 1900) &&                                    \
 	not(defined(__APPLE__) && defined(__clang__) &&                            \

--- a/SudokuTests/Location.cpp
+++ b/SudokuTests/Location.cpp
@@ -43,18 +43,16 @@ namespace compiletime
 	static_assert(not std::is_const_v<typeT>);
 	static_assert(not std::is_volatile_v<typeT>);
 	static_assert(not std::is_trivial_v<typeT>);
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(_MSC_VER) && _MSC_VER < 1927
+	static_assert(not std::is_trivially_copyable_v<typeT>);
+#else
 	static_assert(std::is_trivially_copyable_v<typeT>);
-#if not(defined(__clang__) && __clang_major__ < 6) &&                          \
-	not(defined(__APPLE__) && defined(__clang__) && __clang_major__ < 10)
+#if !(defined(__clang__) && __clang_major__ < 6) &&                            \
+	!(defined(__APPLE__) && defined(__clang__) && __clang_major__ < 10) &&     \
+	!(defined(__ICL) && __ICL <= 1900)
 	static_assert(std::has_unique_object_representations_v<typeT>);
 #endif
-#else
-	static_assert(not std::is_trivially_copyable_v<typeT>);
-#if not(defined(__ICL) && __ICL <= 1900)
-	static_assert(not std::has_unique_object_representations_v<typeT>);
-#endif // __ICL
-#endif // __clang__
+#endif // older compilers
 	static_assert(std::is_standard_layout_v<typeT>);
 	static_assert(not std::is_empty_v<typeT>); // nothing virtual
 	static_assert(not std::is_polymorphic_v<typeT>);
@@ -156,7 +154,7 @@ namespace Location_Block_compiletime
 	static_assert(not std::is_const_v<typeT>);
 	static_assert(not std::is_volatile_v<typeT>);
 	static_assert(not std::is_trivial_v<typeT>);
-#if defined(__GNUC__) && !defined(__clang__)
+#if !defined(__clang__) && !(defined(_MSC_VER) && _MSC_VER < 1927)
 	static_assert(std::is_trivially_copyable_v<typeT>);
 	static_assert(std::has_unique_object_representations_v<typeT>);
 #else

--- a/SudokuTests/Location.cpp
+++ b/SudokuTests/Location.cpp
@@ -43,7 +43,7 @@ namespace compiletime
 	static_assert(not std::is_const_v<typeT>);
 	static_assert(not std::is_volatile_v<typeT>);
 	static_assert(not std::is_trivial_v<typeT>);
-#if defined(_MSC_VER) && _MSC_VER < 1927
+#if defined(_MSC_VER) && _MSC_VER < 1927 && !defined(__clang__)
 	static_assert(not std::is_trivially_copyable_v<typeT>);
 #else
 	static_assert(std::is_trivially_copyable_v<typeT>);


### PR DESCRIPTION
Two of the "excessive" tests in the code detected MSVC changed how types are identified as trivially copyable.

Now the behaviour matches GCC and Clang.